### PR TITLE
認可リクエスト時にstateを追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test:e2e": "vue-cli-service test:e2e"
   },
   "dependencies": {
-    "@types/uuid": "^3.4.4",
     "axios": "^0.18.0",
+    "uuid": "^3.3.2",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^23.1.4",
+    "@types/uuid": "^3.4.4",
     "@vue/cli-plugin-babel": "^3.0.1",
     "@vue/cli-plugin-e2e-cypress": "^3.0.1",
     "@vue/cli-plugin-eslint": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "vue-cli-service test:e2e"
   },
   "dependencies": {
+    "@types/uuid": "^3.4.4",
     "axios": "^0.18.0",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",

--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <h1>Error</h1>
+    <p>
+      {{ errorMessage }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class Login extends Vue {
+  @Prop()
+  errorMessage!: string;
+}
+</script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -30,7 +30,8 @@ export default class Login extends Vue {
     const params: IAuthorizationResponse = {
       code: query.code,
       callbackState: query.state,
-      localState: window.localStorage.getItem(STORAGE_KEY_AUTH_STATE)
+      localState:
+        window.localStorage.getItem(STORAGE_KEY_AUTH_STATE) || undefined
     };
 
     this.$router.push({ query: {} });

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -9,6 +9,7 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Getter, Action, namespace } from "vuex-class";
+import { IAuthorizationResponse, STORAGE_KEY_AUTH_STATE } from "@/domain/Qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
@@ -25,9 +26,15 @@ export default class Login extends Vue {
   issueAccessToken!: (query: object) => void;
 
   created(): void {
-    const query: object = this.$route.query;
+    const query: any = this.$route.query;
+    const params: IAuthorizationResponse = {
+      code: query.code,
+      callbackState: query.state,
+      localState: window.localStorage.getItem(STORAGE_KEY_AUTH_STATE)
+    };
+
     this.$router.push({ query: {} });
-    this.issueAccessToken(query);
+    this.issueAccessToken(params);
   }
 }
 </script>

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -1,5 +1,7 @@
 import { QiitaAPI } from "@/api/qiita";
 
+export const STORAGE_KEY_AUTH_STATE = "authorizationState";
+
 export interface IAuthorizationRequest {
   clientId: string;
   state: string;
@@ -7,7 +9,8 @@ export interface IAuthorizationRequest {
 
 export interface IAuthorizationResponse {
   code: string;
-  state: string;
+  callbackState: string;
+  localState: string | null;
 }
 
 export interface IIssueAccessTokensRequest {

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -10,7 +10,7 @@ export interface IAuthorizationRequest {
 export interface IAuthorizationResponse {
   code: string;
   callbackState: string;
-  localState: string | null;
+  localState?: string;
 }
 
 export interface IIssueAccessTokensRequest {

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -1,5 +1,15 @@
 import { QiitaAPI } from "@/api/qiita";
 
+export interface IAuthorizationRequest {
+  clientId: string;
+  state: string;
+}
+
+export interface IAuthorizationResponse {
+  code: string;
+  state: string;
+}
+
 export interface IIssueAccessTokensRequest {
   client_id: string;
   client_secret: string;
@@ -20,8 +30,12 @@ export interface IFetchAuthenticatedUserResponse {
   permanent_id: string;
 }
 
-export const requestToAuthorizationServer = (clientId: string) => {
-  location.href = `http://qiita.com/api/v2/oauth/authorize?client_id=${clientId}&scope=read_qiita`;
+export const requestToAuthorizationServer = (
+  authorizationRequest: IAuthorizationRequest
+) => {
+  location.href = `http://qiita.com/api/v2/oauth/authorize?client_id=${
+    authorizationRequest.clientId
+  }&scope=read_qiita&state=${authorizationRequest.state}`;
 };
 
 export const issueAccessToken = async (
@@ -34,4 +48,15 @@ export const fetchAuthenticatedUser = async (
   request: IFetchAuthenticatedUserRequest
 ): Promise<IFetchAuthenticatedUserResponse> => {
   return await QiitaAPI.fetchAuthenticatedUser(request);
+};
+
+export const matchState = (responseState: string, state: string): boolean => {
+  if (responseState !== state) {
+    return false;
+  }
+  return true;
+};
+
+export const stateNotMatchedMessage = (): string => {
+  return "不正なリクエストが行われました。再度、ユーザ登録を行なってください。";
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ import Router from "vue-router";
 import Counter from "./components/Counter.vue";
 import Weather from "./components/Weather.vue";
 import Login from "./components/Login.vue";
+import Error from "./components/Error.vue";
 import Home from "./views/Home.vue";
 
 Vue.use(Router);
@@ -30,6 +31,12 @@ export default new Router({
       path: "/login",
       name: "login",
       component: Login
+    },
+    {
+      path: "/error",
+      name: "error",
+      component: Error,
+      props: true
     }
   ]
 });

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -74,7 +74,7 @@ const actions: ActionTree<LoginState, RootState> = {
     }
 
     if (
-      params.localState === null ||
+      params.localState === undefined ||
       !matchState(params.callbackState, params.localState)
     ) {
       router.push({

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -3,7 +3,8 @@ import { QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
 import {
   IIssueAccessTokensResponse,
-  IFetchAuthenticatedUserResponse
+  IFetchAuthenticatedUserResponse,
+  IAuthorizationResponse
 } from "@/domain/Qiita";
 
 jest.mock("@/domain/Qiita");
@@ -110,10 +111,14 @@ describe("QiitaModule", () => {
 
       const commit = jest.fn();
 
-      const routeQuery = { code: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f" };
+      const params: IAuthorizationResponse = {
+        code: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
+        callbackState: "89bd7d77-b352-45f8-9585-388939d426ad",
+        localState: "89bd7d77-b352-45f8-9585-388939d426ad"
+      };
 
       const wrapper = (actions: any) =>
-        actions.issueAccessToken({ commit }, routeQuery);
+        actions.issueAccessToken({ commit }, params);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
@@ -121,6 +126,22 @@ describe("QiitaModule", () => {
         ["saveAccessToken", "72d79c218c16c65b8076c7de8ef6ec55504ca6a0"],
         ["savePermanentId", "1"]
       ]);
+    });
+
+    it("should not commit when callbackState don't match localState", async () => {
+      const commit = jest.fn();
+
+      const params: IAuthorizationResponse = {
+        code: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
+        callbackState: "callbackState-45f8-9585-388939d426ad",
+        localState: "localState-52-45f8-9585-388939d426ad"
+      };
+
+      const wrapper = (actions: any) =>
+        actions.issueAccessToken({ commit }, params);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([]);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,10 @@
   version "2.2.44"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.44.tgz#1d4a798e53f35212fd5ad4d04050620171cd5b5e"
 
+"@types/node@*":
+  version "10.11.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
+
 "@types/node@^10.5.2":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
@@ -772,6 +776,12 @@
 "@types/strip-json-comments@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
+
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  dependencies:
+    "@types/node" "*"
 
 "@vue/babel-preset-app@^3.0.1":
   version "3.0.1"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/21

# Doneの定義
- 認可リクエスト時にstateが追加されていること
- stateが不正だった場合エラー画面が表示されること

# 変更点概要
## 技術的変更点概要
stateで使用するトークンを発行するために`@types/uuid`をインストール。
uuidで生成したstateはLocalStregeに保存し、レスポンスのStateと一致するか確認を行なっている。
Stateが不一致だった場合にエラー画面を表示するため、VueRouterにエラー時の遷移処理を追加した。