### PR TITLE
アカウント作成APIへのリクエスト処理を作成

### DIFF
--- a/src/api/qiitaStocker.ts
+++ b/src/api/qiitaStocker.ts
@@ -6,14 +6,18 @@ export const QiitaStockerAPI = {
     request: ICreateAccountRequest
   ): Promise<ICreateAccountResponse> => {
     return await axios
-      .post<any>(`${request.apiUrlBase}/api/accounts`, request, {
-        headers: {
-          // "application/json"を指定すると以下のエラーとなるので、いったん"multipart/form-data"を指定する
-          // Response to preflight request doesn't pass access control check
-          // "Content-Type": "application/json"
-          "Content-Type": "multipart/form-data"
+      .post<ICreateAccountResponse>(
+        `${request.apiUrlBase}/api/accounts`,
+        request,
+        {
+          headers: {
+            // "application/json"を指定すると以下のエラーとなるので、いったん"application/x-www-form-urlencoded"を指定する
+            // Response to preflight request doesn't pass access control check
+            // "Content-Type": "application/json"
+            "Content-Type": "application/x-www-form-urlencoded"
+          }
         }
-      })
+      )
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve(axiosResponse.data);
       })

--- a/src/api/qiitaStocker.ts
+++ b/src/api/qiitaStocker.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosResponse, AxiosError } from "axios";
+import { ICreateAccountRequest, ICreateAccountResponse } from "@/domain/Qiita";
+
+export const QiitaStockerAPI = {
+  createAccount: async (
+    request: ICreateAccountRequest
+  ): Promise<ICreateAccountResponse> => {
+    return await axios
+      .post<any>(`${request.apiUrlBase}/api/accounts`, request, {
+        headers: {
+          // "application/json"を指定すると以下のエラーとなるので、いったん"multipart/form-data"を指定する
+          // Response to preflight request doesn't pass access control check
+          // "Content-Type": "application/json"
+          "Content-Type": "multipart/form-data"
+        }
+      })
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: AxiosError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+};

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -1,4 +1,5 @@
 import { QiitaAPI } from "@/api/qiita";
+import { QiitaStockerAPI } from "@/api/qiitaStocker";
 
 export const STORAGE_KEY_AUTH_STATE = "authorizationState";
 
@@ -33,6 +34,17 @@ export interface IFetchAuthenticatedUserResponse {
   permanent_id: string;
 }
 
+export interface ICreateAccountRequest {
+  apiUrlBase: string;
+  permanentId: string;
+  accessToken: string;
+}
+
+export interface ICreateAccountResponse {
+  accountId: string;
+  _embedded: { sessionId: string };
+}
+
 export const requestToAuthorizationServer = (
   authorizationRequest: IAuthorizationRequest
 ) => {
@@ -51,6 +63,12 @@ export const fetchAuthenticatedUser = async (
   request: IFetchAuthenticatedUserRequest
 ): Promise<IFetchAuthenticatedUserResponse> => {
   return await QiitaAPI.fetchAuthenticatedUser(request);
+};
+
+export const createAccount = async (
+  request: ICreateAccountRequest
+): Promise<ICreateAccountResponse> => {
+  return await QiitaStockerAPI.createAccount(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -14,7 +14,10 @@ import {
   IAuthorizationRequest,
   stateNotMatchedMessage,
   matchState,
-  STORAGE_KEY_AUTH_STATE
+  STORAGE_KEY_AUTH_STATE,
+  createAccount,
+  ICreateAccountRequest,
+  ICreateAccountResponse
 } from "@/domain/Qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -23,6 +26,7 @@ Vue.use(Vuex);
 
 const clientId: any = process.env.VUE_APP_QIITA_CLIENT_ID;
 const clientSecret: any = process.env.VUE_APP_QIITA_CLIENT_SECRET;
+const apiUrlBase: any = process.env.VUE_APP_API_URL_BASE;
 
 const state: LoginState = {
   authorizationCode: "",
@@ -108,6 +112,19 @@ const actions: ActionTree<LoginState, RootState> = {
       );
 
       commit("savePermanentId", authenticatedUser.permanent_id);
+
+      const createAccountRequest: ICreateAccountRequest = {
+        apiUrlBase: apiUrlBase,
+        permanentId: authenticatedUser.permanent_id,
+        accessToken: response.token
+      };
+
+      const createAccountResponse: ICreateAccountResponse = await createAccount(
+        createAccountRequest
+      );
+
+      console.log(createAccountResponse.accountId);
+      console.log(createAccountResponse._embedded.sessionId);
     } catch (error) {
       console.log(error);
     }

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -24,9 +24,22 @@ import router from "@/router";
 
 Vue.use(Vuex);
 
-const clientId: any = process.env.VUE_APP_QIITA_CLIENT_ID;
-const clientSecret: any = process.env.VUE_APP_QIITA_CLIENT_SECRET;
-const apiUrlBase: any = process.env.VUE_APP_API_URL_BASE;
+const clientId = (): string => {
+  return process.env.VUE_APP_QIITA_CLIENT_ID === undefined
+    ? ""
+    : process.env.VUE_APP_QIITA_CLIENT_ID;
+};
+
+const clientSecret = (): string => {
+  return process.env.VUE_APP_QIITA_CLIENT_SECRET === undefined
+    ? ""
+    : process.env.VUE_APP_QIITA_CLIENT_SECRET;
+};
+const apiUrlBase = (): string => {
+  return process.env.VUE_APP_API_URL_BASE === undefined
+    ? ""
+    : process.env.VUE_APP_API_URL_BASE;
+};
 
 const state: LoginState = {
   authorizationCode: "",
@@ -65,7 +78,7 @@ const actions: ActionTree<LoginState, RootState> = {
     window.localStorage.setItem(STORAGE_KEY_AUTH_STATE, state);
 
     const authorizationRequest: IAuthorizationRequest = {
-      clientId: clientId,
+      clientId: clientId(),
       state: state
     };
 
@@ -92,8 +105,8 @@ const actions: ActionTree<LoginState, RootState> = {
     commit("saveAuthorizationCode", authorizationCode);
 
     const issueAccessTokensRequest: IIssueAccessTokensRequest = {
-      client_id: clientId,
-      client_secret: clientSecret,
+      client_id: clientId(),
+      client_secret: clientSecret(),
       code: authorizationCode
     };
 
@@ -114,7 +127,7 @@ const actions: ActionTree<LoginState, RootState> = {
       commit("savePermanentId", authenticatedUser.permanent_id);
 
       const createAccountRequest: ICreateAccountRequest = {
-        apiUrlBase: apiUrlBase,
+        apiUrlBase: apiUrlBase(),
         permanentId: authenticatedUser.permanent_id,
         accessToken: response.token
       };


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/22

# Doneの定義
- アカウント作成APIとフロントエンドが通信できていること

# 変更点概要

## 仕様的変更点概要
アカウント作成APIへのリクエスト処理を追加。
セッションIDやアカウントIDの保存処理は別のIssueにて対応。

## 技術的変更点概要
API側でpreflightリクエストの対応をしていないので、preflightリクエストが送信されないように、
`Content-Type`は、いったん`multipart/form-data`を指定する。