### PR TITLE
アカウント登録する画面を作成する

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -19,7 +19,7 @@ export default class Login extends Vue {
   login!: () => void;
 
   @QiitaAction
-  issueAccessToken!: (query: object) => void;
+  createAccount!: (query: object) => void;
 
   created(): void {
     const query: any = this.$route.query;
@@ -31,7 +31,7 @@ export default class Login extends Vue {
     };
 
     this.$router.push({ query: {} });
-    this.issueAccessToken(params);
+    this.createAccount(params);
   }
 }
 </script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -17,21 +17,5 @@ const QiitaGetter = namespace("QiitaModule", Getter);
 export default class Login extends Vue {
   @QiitaAction
   login!: () => void;
-
-  @QiitaAction
-  createAccount!: (query: object) => void;
-
-  created(): void {
-    const query: any = this.$route.query;
-    const params: IAuthorizationResponse = {
-      code: query.code,
-      callbackState: query.state,
-      localState:
-        window.localStorage.getItem(STORAGE_KEY_AUTH_STATE) || undefined
-    };
-
-    this.$router.push({ query: {} });
-    this.createAccount(params);
-  }
 }
 </script>

--- a/src/components/SignUp.vue
+++ b/src/components/SignUp.vue
@@ -23,7 +23,7 @@ export default class Login extends Vue {
   signUp!: () => void;
 
   @QiitaAction
-  issueAccessToken!: (query: object) => void;
+  createAccount!: (query: object) => void;
 
   created(): void {
     const query: any = this.$route.query;
@@ -35,7 +35,7 @@ export default class Login extends Vue {
     };
 
     this.$router.push({ query: {} });
-    this.issueAccessToken(params);
+    this.createAccount(params);
   }
 }
 </script>

--- a/src/components/SignUp.vue
+++ b/src/components/SignUp.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
-    <h1>ログイン</h1>
-    <button @click="login">Qiitaアカウントでログイン</button>
+    <h1>アカウント作成</h1>
+    <button @click="signUp">Qiitaアカウントで登録</button>
+    <p v-show="permanentId">PermanentId :{{ permanentId }}</p>
   </div>
 </template>
 
@@ -15,8 +16,11 @@ const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
 export default class Login extends Vue {
+  @QiitaGetter
+  permanentId!: string;
+
   @QiitaAction
-  login!: () => void;
+  signUp!: () => void;
 
   @QiitaAction
   issueAccessToken!: (query: object) => void;

--- a/src/components/SignUp.vue
+++ b/src/components/SignUp.vue
@@ -15,7 +15,7 @@ const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
-export default class Login extends Vue {
+export default class SignUp extends Vue {
   @QiitaGetter
   permanentId!: string;
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Router from "vue-router";
 import Counter from "./components/Counter.vue";
 import Weather from "./components/Weather.vue";
+import SignUp from "./components/SignUp.vue";
 import Login from "./components/Login.vue";
 import Error from "./components/Error.vue";
 import Home from "./views/Home.vue";
@@ -31,6 +32,11 @@ export default new Router({
       path: "/login",
       name: "login",
       component: Login
+    },
+    {
+      path: "/signup",
+      name: "signup",
+      component: SignUp
     },
     {
       path: "/error",

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -84,8 +84,7 @@ const actions: ActionTree<LoginState, RootState> = {
 
     requestToAuthorizationServer(authorizationRequest);
   },
-  // アカウント作成APIにリクエストを送信する処理を追加する時点でメソッド名を変更する
-  issueAccessToken: async ({ commit }, params: IAuthorizationResponse) => {
+  createAccount: async ({ commit }, params: IAuthorizationResponse) => {
     if (params.code === undefined) {
       return;
     }

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -72,7 +72,7 @@ const mutations: MutationTree<LoginState> = {
 };
 
 const actions: ActionTree<LoginState, RootState> = {
-  login: ({ commit }) => {
+  signUp: ({ commit }) => {
     const state = uuid.v4();
 
     window.localStorage.setItem(STORAGE_KEY_AUTH_STATE, state);
@@ -141,6 +141,9 @@ const actions: ActionTree<LoginState, RootState> = {
     } catch (error) {
       console.log(error);
     }
+  },
+  login: ({ commit }) => {
+    // TODO ログインAPIを呼び出す処理を追加する
   }
 };
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -8,6 +8,9 @@
          <router-link to="/weather">weather</router-link>
        </li>
        <li>
+         <router-link to="/signUp">sign up</router-link>
+       </li>
+       <li>
          <router-link to="/login">login</router-link>
        </li>
      </ul>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -8,7 +8,7 @@
          <router-link to="/weather">weather</router-link>
        </li>
        <li>
-         <router-link to="/signUp">sign up</router-link>
+         <router-link to="/signup">sign up</router-link>
        </li>
        <li>
          <router-link to="/login">login</router-link>

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -27,7 +27,7 @@ describe("Login.vue", () => {
 
     actions = {
       login: jest.fn(),
-      issueAccessToken: jest.fn()
+      createAccount: jest.fn()
     };
 
     store = new Vuex.Store({

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -118,7 +118,7 @@ describe("QiitaModule", () => {
       };
 
       const wrapper = (actions: any) =>
-        actions.issueAccessToken({ commit }, params);
+        actions.createAccount({ commit }, params);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
@@ -138,7 +138,7 @@ describe("QiitaModule", () => {
       };
 
       const wrapper = (actions: any) =>
-        actions.issueAccessToken({ commit }, params);
+        actions.createAccount({ commit }, params);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([]);

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -1,0 +1,50 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import Vuex from "vuex";
+import SignUp from "../../src/components/SignUp.vue";
+import { QiitaModule } from "@/store/modules/Qiita";
+
+import { LoginState } from "@/types/login";
+import VueRouter from "vue-router";
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+const router = new VueRouter();
+
+describe("SignUp.vue", () => {
+  let store: any;
+  let state: LoginState;
+  let actions: any;
+
+  it('calls store action "signUp" when button is clicked', () => {
+    state = {
+      authorizationCode: "",
+      accessToken: "",
+      permanentId: ""
+    };
+
+    actions = {
+      signUp: jest.fn(),
+      issueAccessToken: jest.fn()
+    };
+
+    store = new Vuex.Store({
+      modules: {
+        QiitaModule: {
+          namespaced: true,
+          state,
+          actions,
+          getters: QiitaModule.getters
+        }
+      }
+    });
+
+    const wrapper = shallowMount(SignUp, { store, localVue, router });
+    const button = wrapper.find("button");
+
+    button.trigger("click");
+    expect(actions.signUp).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -27,7 +27,7 @@ describe("SignUp.vue", () => {
 
     actions = {
       signUp: jest.fn(),
-      issueAccessToken: jest.fn()
+      createAccount: jest.fn()
     };
 
     store = new Vuex.Store({


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/28

# Doneの定義
- アカウント作成画面が作成されていること
- 現在のログイン画面はログイン処理を行う

# 変更点概要

## 仕様的変更点概要
- `http://localhost:8080/signup`
アカウント作成画面を表示し、QiitaStockerのアカウントを作成する
- `http://localhost:8080/login`
ログイン画面を表示。
ログインAPIの呼び出し処理は、別のIssueにて対応予定。

## 技術的変更点概要
既存のLoginコンポーネントを処理自体は変更せず、SignUpコンポーネントにコンポーネント名を修正。
Loginコンポーネントは、ログインボタンのみ表示。
Qiitaアプリケーションで設定しているリダイレクト先のURLは、`http://localhost:8080/signup`に変更。