### PR TITLE
callbackコンポーネントを作成する

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -7,11 +7,9 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { Getter, Action, namespace } from "vuex-class";
-import { IAuthorizationResponse, STORAGE_KEY_AUTH_STATE } from "@/domain/Qiita";
+import { Action, namespace } from "vuex-class";
 
 const QiitaAction = namespace("QiitaModule", Action);
-const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
 export default class Login extends Vue {

--- a/src/components/OAuthCallback.vue
+++ b/src/components/OAuthCallback.vue
@@ -7,14 +7,24 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Action, namespace } from "vuex-class";
-import { IAuthorizationResponse, STORAGE_KEY_AUTH_STATE } from "@/domain/Qiita";
+import {
+  IAuthorizationResponse,
+  STORAGE_KEY_AUTH_STATE,
+  STORAGE_KEY_ACCOUNT_ACTION
+} from "@/domain/Qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
 
 @Component
 export default class OAuthCallback extends Vue {
   @QiitaAction
-  createAccount!: (query: object) => void;
+  fetchUser!: (query: object) => void;
+
+  @QiitaAction
+  createAccount!: () => void;
+
+  @QiitaAction
+  issueLoginSession!: () => void;
 
   created(): void {
     const query: any = this.$route.query;
@@ -26,7 +36,21 @@ export default class OAuthCallback extends Vue {
     };
 
     this.$router.push({ query: {} });
-    this.createAccount(params);
+
+    const accountAction: string =
+      window.localStorage.getItem(STORAGE_KEY_ACCOUNT_ACTION) || "";
+
+    switch (accountAction) {
+      case "signUp":
+        this.createAccount();
+        break;
+      case "login":
+        this.issueLoginSession();
+        break;
+      default:
+        // TODO エラー処理を追加
+        console.log("ERROR!");
+    }
   }
 }
 </script>

--- a/src/components/OAuthCallback.vue
+++ b/src/components/OAuthCallback.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <h1>Logging in...</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { Action, namespace } from "vuex-class";
+import { IAuthorizationResponse, STORAGE_KEY_AUTH_STATE } from "@/domain/Qiita";
+
+const QiitaAction = namespace("QiitaModule", Action);
+
+@Component
+export default class OAuthCallback extends Vue {
+  @QiitaAction
+  createAccount!: (query: object) => void;
+
+  created(): void {
+    const query: any = this.$route.query;
+    const params: IAuthorizationResponse = {
+      code: query.code,
+      callbackState: query.state,
+      localState:
+        window.localStorage.getItem(STORAGE_KEY_AUTH_STATE) || undefined
+    };
+
+    this.$router.push({ query: {} });
+    this.createAccount(params);
+  }
+}
+</script>

--- a/src/components/SignUp.vue
+++ b/src/components/SignUp.vue
@@ -9,7 +9,6 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Getter, Action, namespace } from "vuex-class";
-import { IAuthorizationResponse, STORAGE_KEY_AUTH_STATE } from "@/domain/Qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
@@ -21,21 +20,5 @@ export default class SignUp extends Vue {
 
   @QiitaAction
   signUp!: () => void;
-
-  @QiitaAction
-  createAccount!: (query: object) => void;
-
-  created(): void {
-    const query: any = this.$route.query;
-    const params: IAuthorizationResponse = {
-      code: query.code,
-      callbackState: query.state,
-      localState:
-        window.localStorage.getItem(STORAGE_KEY_AUTH_STATE) || undefined
-    };
-
-    this.$router.push({ query: {} });
-    this.createAccount(params);
-  }
 }
 </script>

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -2,6 +2,7 @@ import { QiitaAPI } from "@/api/qiita";
 import { QiitaStockerAPI } from "@/api/qiitaStocker";
 
 export const STORAGE_KEY_AUTH_STATE = "authorizationState";
+export const STORAGE_KEY_ACCOUNT_ACTION = "accountAction";
 
 export interface IAuthorizationRequest {
   clientId: string;

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,7 @@ import Counter from "./components/Counter.vue";
 import Weather from "./components/Weather.vue";
 import SignUp from "./components/SignUp.vue";
 import Login from "./components/Login.vue";
+import OAuthCallback from "./components/OAuthCallback.vue";
 import Error from "./components/Error.vue";
 import Home from "./views/Home.vue";
 
@@ -37,6 +38,11 @@ export default new Router({
       path: "/signup",
       name: "signup",
       component: SignUp
+    },
+    {
+      path: "/oauth/callback",
+      name: "oAuthCallback",
+      component: OAuthCallback
     },
     {
       path: "/error",

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -90,7 +90,7 @@ describe("QiitaModule", () => {
   });
 
   describe("actions", () => {
-    it("should be able to issue AccessTokens from Qiita API", async () => {
+    it("should be able to fetch user from Qiita API", async () => {
       const mockPostResponse: { data: IIssueAccessTokensResponse } = {
         data: {
           client_id: "4f54451e86041b5c0a29419b4058f44b5ea04ae9",
@@ -117,8 +117,7 @@ describe("QiitaModule", () => {
         localState: "89bd7d77-b352-45f8-9585-388939d426ad"
       };
 
-      const wrapper = (actions: any) =>
-        actions.createAccount({ commit }, params);
+      const wrapper = (actions: any) => actions.fetchUser({ commit }, params);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
@@ -137,8 +136,7 @@ describe("QiitaModule", () => {
         localState: "localState-52-45f8-9585-388939d426ad"
       };
 
-      const wrapper = (actions: any) =>
-        actions.createAccount({ commit }, params);
+      const wrapper = (actions: any) => actions.fetchUser({ commit }, params);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([]);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/29

# Doneの定義
- 認可サーバからのコールバック先が`http://localhost:8080/oauth/callback`に変更されていること
- アカウント作成APIとログインAPIへのリクエストが可能となっていること

※ログインAPIへのリクエスト処理は別のPRにて対応

# 変更点概要

## 仕様的変更点概要
- 認可サーバからのコールバック先を`http://localhost:8080/signup`から
`http://localhost:8080/oauth/callback`に変更

## 技術的変更点概要
- 認可サーバからコールバックされた場合に表示するOAuthCallbackコンポーネントを作成
- SignUpコンポーネントで行っていた以下の処理をOAuthCallback コンポーネントに移動
  - アクセストークンの発行
  - 認証済みユーザ情報の取得
  - アカウント作成APIへのリクエスト
- OAuthCallback コンポーネントでアカウント作成とログインAPIを呼び出すための判定をするために
各ボタンが押下されたタイミングでLocalStrageに`signup`もしくは`login`を保存している
- ログインAPIを呼び出すためのactionを追加
(ただし、実際のAPIへのリクエスト処理は別のPRにて対応する)
