### PR TITLE
ログインAPIへのリクエスト処理を作成する

### DIFF
--- a/src/api/qiitaStocker.ts
+++ b/src/api/qiitaStocker.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosResponse, AxiosError } from "axios";
-import { ICreateAccountRequest, ICreateAccountResponse } from "@/domain/Qiita";
+import {
+  ICreateAccountRequest,
+  ICreateAccountResponse,
+  IIssueLoginSessionRequest,
+  IIssueLoginSessionResponse
+} from "@/domain/Qiita";
 
 export const QiitaStockerAPI = {
   createAccount: async (
@@ -14,6 +19,26 @@ export const QiitaStockerAPI = {
             // "application/json"を指定すると以下のエラーとなるので、いったん"application/x-www-form-urlencoded"を指定する
             // Response to preflight request doesn't pass access control check
             // "Content-Type": "application/json"
+            "Content-Type": "application/x-www-form-urlencoded"
+          }
+        }
+      )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: AxiosError) => {
+        return Promise.reject(axiosError);
+      });
+  },
+  issueLoginSession: async (
+    request: IIssueLoginSessionRequest
+  ): Promise<IIssueLoginSessionResponse> => {
+    return await axios
+      .post<IIssueLoginSessionResponse>(
+        `${request.apiUrlBase}/api/login-sessions`,
+        request,
+        {
+          headers: {
             "Content-Type": "application/x-www-form-urlencoded"
           }
         }

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -46,6 +46,16 @@ export interface ICreateAccountResponse {
   _embedded: { sessionId: string };
 }
 
+export interface IIssueLoginSessionRequest {
+  apiUrlBase: string;
+  permanentId: string;
+  accessToken: string;
+}
+
+export interface IIssueLoginSessionResponse {
+  sessionId: string;
+}
+
 export const requestToAuthorizationServer = (
   authorizationRequest: IAuthorizationRequest
 ) => {
@@ -70,6 +80,12 @@ export const createAccount = async (
   request: ICreateAccountRequest
 ): Promise<ICreateAccountResponse> => {
   return await QiitaStockerAPI.createAccount(request);
+};
+
+export const issueLoginSession = async (
+  request: IIssueLoginSessionRequest
+): Promise<IIssueLoginSessionResponse> => {
+  return await QiitaStockerAPI.issueLoginSession(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -18,7 +18,10 @@ import {
   STORAGE_KEY_ACCOUNT_ACTION,
   createAccount,
   ICreateAccountRequest,
-  ICreateAccountResponse
+  ICreateAccountResponse,
+  IIssueLoginSessionRequest,
+  IIssueLoginSessionResponse,
+  issueLoginSession
 } from "@/domain/Qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -145,9 +148,23 @@ const actions: ActionTree<LoginState, RootState> = {
       console.log(error);
     }
   },
-  issueLoginSession: ({ commit }) => {
-    // TODO ログインAPIを呼び出す処理を追加する
-    console.log("request LoginAPI");
+  issueLoginSession: async ({ commit }) => {
+    try {
+      const issueLoginSessionRequest: IIssueLoginSessionRequest = {
+        apiUrlBase: apiUrlBase(),
+        permanentId: state.permanentId,
+        accessToken: state.accessToken
+      };
+
+      const issueAccessTokensResponse: IIssueLoginSessionResponse = await issueLoginSession(
+        issueLoginSessionRequest
+      );
+
+      console.log(issueAccessTokensResponse.sessionId);
+    } catch (error) {
+      // TODO エラー処理を追加する
+      console.log(error);
+    }
   }
 };
 

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -26,8 +26,7 @@ describe("Login.vue", () => {
     };
 
     actions = {
-      login: jest.fn(),
-      createAccount: jest.fn()
+      login: jest.fn()
     };
 
     store = new Vuex.Store({

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -26,8 +26,7 @@ describe("SignUp.vue", () => {
     };
 
     actions = {
-      signUp: jest.fn(),
-      createAccount: jest.fn()
+      signUp: jest.fn()
     };
 
     store = new Vuex.Store({


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/29

# Doneの定義
- ログイン作成APIとフロントエンドが通信できていること

# 変更点概要

## 仕様的変更点概要
ログインページからログインする処理を作成。

## 技術的変更点概要
ログインAPIをリクエストする処理を追加。
取得したSessionIDを特に処理していないので、テストケースは追加していない。