### PR TITLE
ログイン時のエラーを表示する

### DIFF
--- a/src/api/qiitaStocker.ts
+++ b/src/api/qiitaStocker.ts
@@ -47,7 +47,7 @@ export const QiitaStockerAPI = {
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve(axiosResponse.data);
       })
-      .catch((axiosError: AxiosError) => {
+      .catch((axiosError: IQiitaStockerError) => {
         return Promise.reject(axiosError);
       });
   }

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -21,8 +21,7 @@ import {
   ICreateAccountResponse,
   IIssueLoginSessionRequest,
   IIssueLoginSessionResponse,
-  issueLoginSession,
-  IQiitaStockerError
+  issueLoginSession
 } from "@/domain/Qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -166,8 +165,11 @@ const actions: ActionTree<LoginState, RootState> = {
 
       console.log(issueAccessTokensResponse.sessionId);
     } catch (error) {
-      // TODO エラー処理を追加する
-      console.log(error);
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
     }
   }
 };


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/33

# Doneの定義
- ログインの際、アカウントが登録されていなかった場合エラーが表示されること

# 変更点概要

## 仕様的変更点概要
ログイン時にエラーになった場合に、エラー画面を表示するように修正。

## 技術的変更点概要
レスポンスのエラーメッセージをエラー画面に表示するように修正。