### PR TITLE
退会完了画面を作成する

### DIFF
--- a/src/components/CancelComplete.vue
+++ b/src/components/CancelComplete.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <h1>退会完了</h1>
+    <p>退会が完了しました。<br>
+      ご利用いただき、ありがとうございました。<br>
+      またのご利用をお待ちしております。
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class CancelComplete extends Vue {}
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import SignUp from "./components/SignUp.vue";
 import Login from "./components/Login.vue";
 import OAuthCallback from "./components/OAuthCallback.vue";
 import Cancel from "./components/Cancel.vue";
+import CancelComplete from "./components/CancelComplete.vue";
 import Error from "./components/Error.vue";
 import Home from "./views/Home.vue";
 
@@ -49,6 +50,11 @@ export default new Router({
       path: "/cancel",
       name: "cancel",
       component: Cancel
+    },
+    {
+      path: "/cancel/complete",
+      name: "cancelComplete",
+      component: CancelComplete
     },
     {
       path: "/error",

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -186,7 +186,9 @@ const actions: ActionTree<LoginState, RootState> = {
       // TODO 永続化したセッションIDを削除する処理を追加する
       // TODO 退会完了画面を表示する
 
-      console.log("退会処理が完了しました");
+      router.push({
+        name: "cancelComplete"
+      });
     } catch (error) {
       router.push({
         name: "error",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/46

# Doneの定義
- 退会完了画面が作成されていること

# 変更点概要

## 仕様的変更点概要
アカウントの退会完了後、退会完了ページが表示されるように修正。

## 技術的変更点概要
退会完了コンポーネントを作成。

# 補足
退会完了コンポーネントは、メッセージを表示させるためだけのコンポーネントのため、テストケースは追加していない。