### PR TITLE
アカウント作成後の画面を作成する

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,7 @@ import Counter from "./components/Counter.vue";
 import Weather from "./components/Weather.vue";
 import SignUp from "./components/SignUp.vue";
 import Login from "./components/Login.vue";
+import Account from "./views/Account.vue";
 import OAuthCallback from "./components/OAuthCallback.vue";
 import Cancel from "./components/Cancel.vue";
 import CancelComplete from "./components/CancelComplete.vue";
@@ -40,6 +41,11 @@ export default new Router({
       path: "/signup",
       name: "signup",
       component: SignUp
+    },
+    {
+      path: "/account",
+      name: "account",
+      component: Account
     },
     {
       path: "/oauth/callback",

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -175,7 +175,7 @@ const actions: ActionTree<LoginState, RootState> = {
       console.log(createAccountResponse._embedded.sessionId);
 
       router.push({
-        name: "signup"
+        name: "account"
       });
     } catch (error) {
       router.push({
@@ -200,7 +200,7 @@ const actions: ActionTree<LoginState, RootState> = {
       console.log(issueAccessTokensResponse.sessionId);
 
       router.push({
-        name: "login"
+        name: "account"
       });
     } catch (error) {
       router.push({

--- a/src/views/Account.vue
+++ b/src/views/Account.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1>アカウント</h1>
+    <p>ログイン後に表示される画面</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class Account extends Vue {}
+</script>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/47

# Doneの定義
- アカウント作成後(ログイン後)の画面が作成されていること
- アカウント作成後(ログイン後)リダイレクトされること

# 変更点概要

## 仕様的変更点概要
アカウント作成後(ログイン後)に、アカウント画面を表示する機能を追加。

## 技術的変更点概要
`src/views/Account.vue`を作成。

# 補足情報
暫定で作成した画面のためテストは作成していない。