### PR TITLE
404のエラー画面を作成する

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ import OAuthCallback from "./components/OAuthCallback.vue";
 import Cancel from "./components/Cancel.vue";
 import CancelComplete from "./components/CancelComplete.vue";
 import Error from "./components/Error.vue";
+import NotFound from "./views/NotFound.vue";
 import Home from "./views/Home.vue";
 
 Vue.use(Router);
@@ -67,6 +68,11 @@ export default new Router({
       name: "error",
       component: Error,
       props: true
+    },
+    {
+      path: "*",
+      name: "notFound",
+      component: NotFound
     }
   ]
 });

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1>404 Not Found</h1>
+    <p>アクセスされたページが見つかりません。</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class NotFound extends Vue {}
+</script>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/41

# Doneの定義
存在しないページがリクエストされた場合、404のエラー画面が表示されること

# 変更点概要

## 仕様的変更点概要
存在しないページがリクエストされた場合、Not Foundのページを表示する処理を追加。

## 技術的変更点概要
NotFoundコンポーネントを作成。
どのpathにも当てはまらなかった場合のルーティングを設定。