### PR TITLE
セッションIDを永続化する

### DIFF
--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -4,6 +4,7 @@ import { AxiosResponse, AxiosError } from "axios";
 
 export const STORAGE_KEY_AUTH_STATE = "authorizationState";
 export const STORAGE_KEY_ACCOUNT_ACTION = "accountAction";
+export const STORAGE_KEY_SESSION_ID = "sessionId";
 
 export interface IQiitaStockerSessionStorage {
   save(key: string, value: string): void;

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -175,6 +175,7 @@ const actions: ActionTree<LoginState, RootState> = {
         createAccountRequest
       );
 
+      // TODO 発行されたアカウントIDをstateに保存するのか検討
       console.log(createAccountResponse.accountId);
       localStorage.save(
         STORAGE_KEY_SESSION_ID,
@@ -208,7 +209,6 @@ const actions: ActionTree<LoginState, RootState> = {
         STORAGE_KEY_SESSION_ID,
         issueAccessTokensResponse.sessionId
       );
-      console.log(issueAccessTokensResponse.sessionId);
 
       router.push({
         name: "account"

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -16,6 +16,7 @@ import {
   matchState,
   STORAGE_KEY_AUTH_STATE,
   STORAGE_KEY_ACCOUNT_ACTION,
+  STORAGE_KEY_SESSION_ID,
   createAccount,
   ICreateAccountRequest,
   ICreateAccountResponse,
@@ -175,7 +176,10 @@ const actions: ActionTree<LoginState, RootState> = {
       );
 
       console.log(createAccountResponse.accountId);
-      console.log(createAccountResponse._embedded.sessionId);
+      localStorage.save(
+        STORAGE_KEY_SESSION_ID,
+        createAccountResponse._embedded.sessionId
+      );
 
       router.push({
         name: "account"
@@ -200,6 +204,10 @@ const actions: ActionTree<LoginState, RootState> = {
         issueLoginSessionRequest
       );
 
+      localStorage.save(
+        STORAGE_KEY_SESSION_ID,
+        issueAccessTokensResponse.sessionId
+      );
       console.log(issueAccessTokensResponse.sessionId);
 
       router.push({


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/45

# Doneの定義
- アカウント作成後、セッションIDが永続化されていること
- ログイン後、セッションIDが永続化されていること

# 変更点概要

## 技術的変更点概要
発行されたセッションIDをLocalStorageに永続化する処理を追加。