### PR TITLE
退会完了後に永続化されたセッションIDを削除する

### DIFF
--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -231,7 +231,7 @@ const actions: ActionTree<LoginState, RootState> = {
 
       await cancelAccount(cancelAccountRequest);
 
-      // TODO 永続化したセッションIDを削除する処理を追加する
+      localStorage.remove(STORAGE_KEY_SESSION_ID);
 
       router.push({
         name: "cancelComplete"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/58

# Doneの定義
- 退会完了後、永続化されたセッションIDが削除されていること

# 変更点概要

## 技術的変更点概要
LocalStorageからセッションIDを削除する処理を追加。