### PR TITLE
CSSフレームワークを導入する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "bulma": "^0.7.2",
     "uuid": "^3.3.2",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
 </template>
 
 <style lang="scss">
+@import "../node_modules/bulma/bulma.sass";
 #app {
   font-family: "Avenir", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/pages/SignUp.vue
+++ b/src/pages/SignUp.vue
@@ -1,9 +1,27 @@
 <template>
-  <div>
-    <h1>アカウント作成</h1>
-    <button @click="signUp">Qiitaアカウントで登録</button>
-    <p v-show="permanentId">PermanentId :{{ permanentId }}</p>
-  </div>
+  <section class="hero is-fullheight">
+    <header class="header">
+      <div class="container">
+        <nav class="navbar has-shadow">
+          <div class="navbar-brand">
+            <a class="navbar-item" href="http://localhost:8080">Qiita Stocker</a>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="container">
+        <h1 class="title">アカウント作成</h1>
+        <button class="button" @click="signUp">Qiitaアカウントで登録</button>
+        <p v-show="permanentId">PermanentId :{{ permanentId }}</p>
+      </div>
+    </main>
+    <footer class="footer">
+      <div class="content has-text-centered">
+        <p>Copyright (c) 2018 nekochans</p>
+      </div>
+    </footer>
+  </section>
 </template>
 
 <script lang="ts">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,6 +1877,10 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bulma@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/49

# Doneの定義
- Bulmaが導入されていること
- アカウント作成ページが置き換えられていること

# スクリーンショット
<img width="1440" alt="2018-11-03 13 39 33" src="https://user-images.githubusercontent.com/32682645/47948153-9ab8d080-df6e-11e8-9a4f-9fb8f10eb982.png">

# 変更点概要

## 仕様的変更点概要
アカウント作成画面にヘッダーとフッダーを追加し、スタイルを修正。

## 技術的変更点概要
CSSフレームワークのBulmaを導入。

# 補足
ヘッダーとフッターについてはvueコンポーネントにし、他の画面でも再利用する。
新規Issueを立てて対応する予定。