### PR TITLE
ヘッダーをコンポーネントにする

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,23 @@
+<template>
+  <header class="header">
+    <div class="container">
+      <nav class="navbar has-shadow">
+        <div class="navbar-brand">
+          <a class="navbar-item" href="http://localhost:8080"><p class="is-size-5 has-text-black">Qiita Stocker</p></a>
+        </div>
+        <div class="navbar-end">
+          <div class="navbar-item">
+            <button class="button is-small">ボタン</button>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class Header extends Vue {}
+</script>

--- a/src/pages/SignUp.vue
+++ b/src/pages/SignUp.vue
@@ -1,14 +1,6 @@
 <template>
   <section class="hero is-fullheight">
-    <header class="header">
-      <div class="container">
-        <nav class="navbar has-shadow">
-          <div class="navbar-brand">
-            <a class="navbar-item" href="http://localhost:8080">Qiita Stocker</a>
-          </div>
-        </nav>
-      </div>
-    </header>
+    <Header />
     <main>
       <div class="container">
         <h1 class="title">アカウント作成</h1>
@@ -23,6 +15,7 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Getter, Action, namespace } from "vuex-class";
+import Header from "@/components/Header.vue";
 import Footer from "@/components/Footer.vue";
 
 const QiitaAction = namespace("QiitaModule", Action);
@@ -30,6 +23,7 @@ const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component({
   components: {
+    Header,
     Footer
   }
 })


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/65

# Doneの定義
- ヘッダーコンポーネントが作成されていること

# スクリーンショット
<img width="1439" alt="2018-11-03 20 32 34" src="https://user-images.githubusercontent.com/32682645/47951710-d58b2a80-dfa7-11e8-88cd-e649e5be8289.png">

# 変更点概要

## 技術的変更点概要
- アカウント作成画面のHeaderをvueのFooterコンポーネントに置き換え。

# 補足情報
Headerの内容は仮とする。
