### PR TITLE
NotFoundページのスタイリング

### DIFF
--- a/src/pages/NotFound.vue
+++ b/src/pages/NotFound.vue
@@ -1,13 +1,33 @@
 <template>
-  <div>
-    <h1>404 Not Found</h1>
-    <p>アクセスされたページが見つかりません。</p>
-  </div>
+  <section class="hero is-fullheight">
+    <Header />
+    <main class="container has-text-centered">
+      <h1 class="title">404 Not Found</h1>
+      <h2 class="subtitle">
+        アクセスされたページが見つかりません。
+      </h2>
+      <a href="/">TOPページへ</a>
+    </main>
+    <Footer />
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import Header from "@/components/Header.vue";
+import Footer from "@/components/Footer.vue";
 
-@Component
+@Component({
+  components: {
+    Header,
+    Footer
+  }
+})
 export default class NotFound extends Vue {}
 </script>
+
+<style scoped>
+.subtitle {
+  padding-top: 1rem;
+}
+</style>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/69

# Doneの定義
- NotFoundページにCSSが当てられている事

# スクリーンショット
<img width="1440" alt="2018-11-05 12 33 52" src="https://user-images.githubusercontent.com/32682645/47976711-16de2000-e0f7-11e8-8843-78eda9040811.png">

# 変更点概要

## 仕様的変更点概要
NotFoundページのスタイルを修正。