### PR TITLE
エラーページのスタイリング

### DIFF
--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -1,18 +1,36 @@
 <template>
-  <div>
-    <h1>Error</h1>
-    <p>
-      {{ errorMessage }}
-    </p>
-  </div>
+  <section class="hero is-fullheight">
+    <Header />
+    <main class="container has-text-centered">
+      <h1 class="title">Error</h1>
+      <h2 class="subtitle">
+        {{ errorMessage }}
+      </h2>
+      <a href="/">TOPページへ</a>
+    </main>
+    <Footer />
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
+import Header from "@/components/Header.vue";
+import Footer from "@/components/Footer.vue";
 
-@Component
+@Component({
+  components: {
+    Header,
+    Footer
+  }
+})
 export default class Error extends Vue {
   @Prop()
   errorMessage!: string;
 }
 </script>
+
+<style scoped>
+.subtitle {
+  padding-top: 1rem;
+}
+</style>

--- a/tests/unit/Error.spec.ts
+++ b/tests/unit/Error.spec.ts
@@ -1,0 +1,18 @@
+import { shallowMount } from "@vue/test-utils";
+import Error from "@/pages/Error.vue";
+
+describe("Cancel.vue", () => {
+  const propsData = {
+    errorMessage: "単体テストのエラーメッセージ。"
+  };
+
+  it("should have the correct props", () => {
+    const wrapper = shallowMount(Error, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  it("renders the correct error message", () => {
+    const wrapper = shallowMount(Error, { propsData });
+    expect(wrapper.find("h2").text()).toBe(propsData.errorMessage);
+  });
+});


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/68

# Doneの定義
- エラーページにCSSが当てられている事

# スクリーンショット
<img width="1440" alt="2018-11-05 14 54 24" src="https://user-images.githubusercontent.com/32682645/47980385-c2dd3680-e10a-11e8-9839-33de013b7345.png">

# 変更点概要

## 仕様的変更点概要
エラーページのスタイルを修正。

## 技術的変更点概要
Errorコンポーネントのテストを追加。
Propsを受け取り、受け取ったエラーメッセージが正しく表示されていることをテスト。