### PR TITLE
ログインページのスタイリング

### DIFF
--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,19 +1,41 @@
 <template>
-  <div>
-    <h1>ログイン</h1>
-    <button @click="login">Qiitaアカウントでログイン</button>
-  </div>
+  <section class="hero is-fullheight">
+    <Header />
+    <main>
+      <div class="container has-text-centered">
+        <h1 class="title">ログイン</h1>
+        <button class="button" @click="login">Qiitaアカウントでログイン</button>
+        <h2 class="is-size-7 login-guide">
+          アカウントを持っていない場合は<a href="/signup">新規登録</a>から
+        </h2>
+      </div>
+    </main>
+    <Footer />
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Action, namespace } from "vuex-class";
+import Header from "@/components/Header.vue";
+import Footer from "@/components/Footer.vue";
 
 const QiitaAction = namespace("QiitaModule", Action);
 
-@Component
+@Component({
+  components: {
+    Header,
+    Footer
+  }
+})
 export default class Login extends Vue {
   @QiitaAction
   login!: () => void;
 }
 </script>
+
+<style scoped>
+.login-guide {
+  padding-top: 1rem;
+}
+</style>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -6,7 +6,7 @@
         <h1 class="title">ログイン</h1>
         <button class="button" @click="login">Qiitaアカウントでログイン</button>
         <h2 class="is-size-7 login-guide">
-          アカウントを持っていない場合は<a href="/signup">新規登録</a>から
+          アカウントを持っていない場合は<a href="/signup">アカウント作成</a>から
         </h2>
       </div>
     </main>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/77

# Doneの定義
- ログインページにCSSが当てられている事

# スクリーンショット
<img width="1440" alt="2018-11-05 16 45 39" src="https://user-images.githubusercontent.com/32682645/47984549-45212700-e11a-11e8-9d57-24a99746e5f2.png">

# 変更点概要

## 仕様的変更点概要
ログインページのスタイルを修正。
アカウント作成画面へのリンクを追加。