### PR TITLE
アカウントページのスタイリング

### DIFF
--- a/src/components/Media.vue
+++ b/src/components/Media.vue
@@ -1,0 +1,44 @@
+<template>
+  <article class="media">
+    <figure class="media-left">
+      <p class="image is-48x48 ">
+        <img src="https://avatars3.githubusercontent.com/u/32682645?v=4">
+      </p>
+    </figure>
+    <div class="media-content">
+      <div class="content">
+        <div class="item-info">
+          <p>m42-kobayashiが2018/1/1に投稿しました</p>
+        </div>
+        <div class="item-title">
+          <a href="https://qiita.com/kobayashi-m42/items/c0a2609ae61a72dcc60f">CORSについて理解してLaravel5.6で対応する</a>
+        </div>
+        <div class="tags">
+          <span class="tag">CORS</span>
+          <span class="tag">laravel5.6</span>
+        </div>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class Media extends Vue {}
+</script>
+
+<style scoped>
+.media {
+  font-size: 12px;
+}
+
+.item-info {
+  font-size: 1em;
+}
+.item-title {
+  margin-bottom: 0.3em;
+  font-size: 1.4em;
+}
+</style>

--- a/src/components/MediaList.vue
+++ b/src/components/MediaList.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <Media />
+    <Media />
+    <Media />
+    <Media />
+    <Media />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import Media from "@/components/Media.vue";
+
+@Component({
+  components: {
+    Media
+  }
+})
+export default class MediaList extends Vue {}
+</script>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,0 +1,29 @@
+<template>
+  <nav class="pagination" role="navigation" aria-label="pagination">
+    <a class="pagination-previous">Previous</a>
+    <a class="pagination-next">Next page</a>
+    <ul class="pagination-list">
+      <li><a class="pagination-link" aria-label="Goto page 1">1</a></li>
+      <li><span class="pagination-ellipsis">&hellip;</span></li>
+      <li><a class="pagination-link" aria-label="Goto page 45">45</a></li>
+      <li><a class="pagination-link is-current" aria-label="Page 46" aria-current="page">46</a></li>
+      <li><a class="pagination-link" aria-label="Goto page 47">47</a></li>
+      <li><span class="pagination-ellipsis">&hellip;</span></li>
+      <li><a class="pagination-link" aria-label="Goto page 86">86</a></li>
+    </ul>
+  </nav>
+
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class Pagination extends Vue {}
+</script>
+
+<style scoped>
+.pagination {
+  margin-top: 2rem;
+}
+</style>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,0 +1,20 @@
+<template>
+  <aside class="submenu menu">
+    <SideMenuSearch/>
+    <SideMenuList />
+  </aside>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import SideMenuSearch from "@/components/SideMenuSearch.vue";
+import SideMenuList from "@/components/SideMenuList.vue";
+
+@Component({
+  components: {
+    SideMenuSearch,
+    SideMenuList
+  }
+})
+export default class SideMenu extends Vue {}
+</script>

--- a/src/components/SideMenuList.vue
+++ b/src/components/SideMenuList.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="side-menu-list">
+    <p class="menu-label">
+      カテゴリ一覧
+    </p>
+    <ul class="menu-list">
+      <li><a class="is-active">未分類</a></li>
+      <li><a>設計</a></li>
+      <li><a>テスト</a></li>
+    </ul>
+  </section>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class SideMenuList extends Vue {}
+</script>
+
+<style scoped>
+.side-menu-list {
+  margin-top: 1em;
+}
+</style>

--- a/src/components/SideMenuSearch.vue
+++ b/src/components/SideMenuSearch.vue
@@ -1,0 +1,24 @@
+<template>
+  <section>
+    <p class="menu-label">
+      タグで検索
+    </p>
+    <div class="field">
+      <input class="input" type="text" placeholder="ストック内を検索">
+    </div>
+    <div class="field">
+      <p class="control">
+        <button class="button is-small">
+          検索
+        </button>
+      </p>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+
+@Component
+export default class SideMenuSearch extends Vue {}
+</script>

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -1,13 +1,40 @@
 <template>
-  <div>
-    <h1>アカウント</h1>
-    <p>ログイン後に表示される画面</p>
-  </div>
+  <section>
+    <Header />
+    <main class="container">
+      <div class="columns">
+        <div class="column is-2">
+          <SideMenu/>
+        </div>
+        <div class="column is-10">
+          <MediaList />
+          <Pagination />
+        </div>
+      </div>
+    </main>
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import Header from "@/components/Header.vue";
+import SideMenu from "@/components/SideMenu.vue";
+import MediaList from "@/components/MediaList.vue";
+import Pagination from "@/components/Pagination.vue";
 
-@Component
+@Component({
+  components: {
+    Header,
+    SideMenu,
+    MediaList,
+    Pagination
+  }
+})
 export default class Account extends Vue {}
 </script>
+
+<style scoped>
+.container {
+  padding-top: 2rem;
+}
+</style>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/78

# Doneの定義
- アカウントページにCSSが当てられている事

# スクリーンショット
<img width="1440" alt="2018-11-06 1 16 08" src="https://user-images.githubusercontent.com/32682645/48010817-addfc200-e161-11e8-8423-3f70489306e1.png">

# 変更点概要

## 仕様的変更点概要
ログイン後のページのスタイルを修正。
Stockの仕様が確定していないので必要になりそうなコンポーネントを作成。
データはダミー。