### PR TITLE
MediaListコンポーネントにpropで記事の一覧を渡す

### DIFF
--- a/src/components/Media.vue
+++ b/src/components/Media.vue
@@ -1,21 +1,26 @@
 <template>
   <article class="media">
     <figure class="media-left">
-      <p class="image is-48x48 ">
-        <img src="https://avatars3.githubusercontent.com/u/32682645?v=4">
-      </p>
+      <a class="image is-48x48" :href="`https://qiita.com/${qiitaItem.userId}`" target="_blank">
+        <img :src="qiitaItem.profile_image_url">
+      </a>
     </figure>
     <div class="media-content">
       <div class="content">
         <div class="item-info">
-          <p>m42-kobayashiが2018/1/1に投稿しました</p>
+          <p><a :href="`https://qiita.com/${qiitaItem.userId}`" target="_blank">{{ qiitaItem.userId }}</a>が{{ qiitaItem.created_at}}に投稿しました</p>
         </div>
         <div class="item-title">
-          <a href="https://qiita.com/kobayashi-m42/items/c0a2609ae61a72dcc60f">CORSについて理解してLaravel5.6で対応する</a>
+          <a :href="`https://qiita.com/kobayashi-m42/items/${qiitaItem.id}`" target="_blank">{{ qiitaItem.title}}</a>
         </div>
         <div class="tags">
-          <span class="tag">CORS</span>
-          <span class="tag">laravel5.6</span>
+          <span
+            v-for="(tag, key) in qiitaItem.tags"
+            :key="key"
+            class="tag"
+          >
+            {{ tag }}
+          </span>
         </div>
       </div>
     </div>
@@ -23,13 +28,25 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { IQiitaItem } from "@/domain/Qiita";
 
 @Component
-export default class Media extends Vue {}
+export default class Media extends Vue {
+  @Prop()
+  qiitaItem!: IQiitaItem[];
+}
 </script>
 
 <style scoped>
+a {
+  color: #337ab7;
+}
+
+a:hover {
+  color: #23527c;
+}
+
 .media {
   font-size: 12px;
 }

--- a/src/components/MediaList.vue
+++ b/src/components/MediaList.vue
@@ -1,10 +1,16 @@
 <template>
   <div>
-    <Media
-      v-for="qiitaItem in qiitaItems"
-      :qiitaItem="qiitaItem"
-      :key="qiitaItem.id"
-    />
+    <div v-if="qiitaItems.length">
+      <Media
+        v-if="qiitaItems.length"
+        v-for="qiitaItem in qiitaItems"
+        :qiitaItem="qiitaItem"
+        :key="qiitaItem.id"
+      />
+    </div>
+    <div v-else>
+      <h1 class="subtitle">ストックされた記事はありません。</h1>
+    </div>
   </div>
 </template>
 

--- a/src/components/MediaList.vue
+++ b/src/components/MediaList.vue
@@ -1,21 +1,25 @@
 <template>
   <div>
-    <Media />
-    <Media />
-    <Media />
-    <Media />
-    <Media />
+    <Media
+      v-for="qiitaItem in qiitaItems"
+      :qiitaItem="qiitaItem"
+      :key="qiitaItem.id"
+    />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Prop } from "vue-property-decorator";
 import Media from "@/components/Media.vue";
+import { IQiitaItem } from "@/domain/Qiita";
 
 @Component({
   components: {
     Media
   }
 })
-export default class MediaList extends Vue {}
+export default class MediaList extends Vue {
+  @Prop()
+  qiitaItems!: IQiitaItem[];
+}
 </script>

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -106,6 +106,16 @@ export interface ICategory {
   name: string;
 }
 
+// TODO 適切な値に修正する
+export interface IQiitaItem {
+  id: string;
+  title: string;
+  created_at: string;
+  tags: string[];
+  userId: string;
+  profile_image_url: string;
+}
+
 export const requestToAuthorizationServer = (
   authorizationRequest: IAuthorizationRequest
 ) => {

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -7,7 +7,7 @@
           <SideMenu :categories="categories" />
         </div>
         <div class="column is-10">
-          <MediaList />
+          <MediaList :qiitaItems="qiitaItems" />
           <Pagination />
         </div>
       </div>
@@ -21,7 +21,7 @@ import Header from "@/components/Header.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import MediaList from "@/components/MediaList.vue";
 import Pagination from "@/components/Pagination.vue";
-import { ICategory } from "@/domain/Qiita";
+import { ICategory, IQiitaItem } from "@/domain/Qiita";
 
 @Component({
   components: {
@@ -44,6 +44,33 @@ export default class Account extends Vue {
     {
       id: 3,
       name: "ドメイン駆動設計"
+    }
+  ];
+
+  qiitaItems: IQiitaItem[] = [
+    {
+      id: "c0a2609ae61a72dcc60f",
+      title: "CORSについて理解してLaravel5.6で対応する",
+      created_at: "2018/09/30",
+      tags: ["CORS", "laravel5.6", "laravel", "php"],
+      userId: "kobayashi-m42",
+      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
+    },
+    {
+      id: "c0a2609ae61a72dcc60f",
+      title: "CORSについて理解してLaravel5.6で対応する",
+      created_at: "2018/09/30",
+      tags: ["CORS", "laravel5.6", "laravel", "php"],
+      userId: "kobayashi-m42",
+      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
+    },
+    {
+      id: "c0a2609ae61a72dcc60f",
+      title: "CORSについて理解してLaravel5.6で対応する",
+      created_at: "2018/09/30",
+      tags: ["CORS", "laravel5.6", "laravel", "php"],
+      userId: "kobayashi-m42",
+      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
     }
   ];
 }

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -57,7 +57,7 @@ export default class Account extends Vue {
       profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
     },
     {
-      id: "c0a2609ae61a72dcc60f",
+      id: "1",
       title: "CORSについて理解してLaravel5.6で対応する",
       created_at: "2018/09/30",
       tags: ["CORS", "laravel5.6", "laravel", "php"],
@@ -65,7 +65,7 @@ export default class Account extends Vue {
       profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
     },
     {
-      id: "c0a2609ae61a72dcc60f",
+      id: "2",
       title: "CORSについて理解してLaravel5.6で対応する",
       created_at: "2018/09/30",
       tags: ["CORS", "laravel5.6", "laravel", "php"],


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/82

# Doneの定義
- propで受け取った記事の一覧が表示されていること
- 記事が存在しなかった場合のメッセージが表示されていること

# スクリーンショット
<img width="1015" alt="2018-11-07 16 28 57" src="https://user-images.githubusercontent.com/32682645/48116706-46815980-e2aa-11e8-9456-cd2bc078d59d.png">

ストックされた記事がなかった場合
<img width="1224" alt="2018-11-07 16 47 16" src="https://user-images.githubusercontent.com/32682645/48117551-e63fe700-e2ac-11e8-9af9-408b4c36ee3a.png">

# 変更点概要

## 仕様的変更点概要
ストックされた記事がなかった場合、以下のメッセージを表示
「ストックされた記事はありません。」

## 技術的変更点概要
`Media`コンポーネントに、propで受け取った記事一覧を表示する処理を追加。