### PR TITLE
カテゴリの登録のUI設計

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name=“robots” content=“noindex”>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>qiita-stocker-frontend</title>
   </head>

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -1,0 +1,90 @@
+<template>
+  <li>
+    <div v-if="!editing">
+      <a
+        :data-category="category.id"
+        @click="clickHandle"
+        :class="`${isActive(category.id) && 'is-active'}`"
+      >
+        {{ category.name }}
+        <p class="edit" @click="editing = true">編集</p>
+      </a>
+    </div>
+    <div v-show="editing">
+      <div class="field">
+        <input
+           class="input"
+           type="text"
+           v-focus="editing"
+           :value="category.name"
+        >
+      </div>
+      <div class="field">
+        <p class="control">
+          <button class="button is-small is-danger" @click="doneEdit">
+            カテゴリを追加
+          </button>
+          <a class="has-text-grey is-size-7 cancel" @click="cancelEdit">キャンセル</a>
+        </p>
+      </div>
+    </div>
+  </li>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { ICategory } from "@/domain/Qiita";
+
+@Component({
+  directives: {
+    focus: function(el, binding) {
+      if (binding.value) {
+        el.focus();
+      }
+    }
+  }
+})
+export default class Category extends Vue {
+  @Prop()
+  category!: ICategory;
+
+  editing: boolean = false;
+
+  clickHandle(event: any) {
+    // TODO 選択されたカテゴリの記事を表示する
+    console.log(`${event.target.dataset.category} clicked!!`);
+  }
+
+  isActive(id: ICategory["id"]) {
+    return id === 1;
+  }
+
+  doneEdit() {
+    this.editing = false;
+  }
+
+  cancelEdit() {
+    this.editing = false;
+  }
+}
+</script>
+
+<style scoped>
+.edit {
+  float: right;
+  display: none;
+  transition: color 0.2s ease-out;
+}
+
+.edit:hover {
+  color: darkgray;
+}
+
+li:hover .edit {
+  display: block;
+}
+
+.cancel {
+  float: right;
+}
+</style>

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -13,11 +13,12 @@
     <div v-show="editing">
       <div class="field">
         <input
-           class="input"
+           class="input edit-field"
            type="text"
            v-focus="editing"
            :value="category.name"
         >
+        <a class="has-text-grey is-size-7 destroy">削除</a>
       </div>
       <div class="field">
         <p class="control">
@@ -85,6 +86,14 @@ li:hover .edit {
 }
 
 .cancel {
+  float: right;
+}
+
+.edit-field {
+  width: auto;
+}
+
+.destroy {
   float: right;
 }
 </style>

--- a/src/components/CreateCategory.vue
+++ b/src/components/CreateCategory.vue
@@ -1,0 +1,60 @@
+<template>
+  <section>
+    <button
+       v-if="!editing"
+       @click="editing = true"
+       class="button view"
+    >
+      カテゴリを追加
+    </button>
+    <div v-show="editing">
+      <div class="field">
+        <input
+          class="input"
+          type="text"
+          v-focus="editing"
+        >
+      </div>
+      <div class="field">
+        <p class="control">
+          <button class="button is-small is-danger" @click="saveCategory">
+            カテゴリを追加
+          </button>
+          <a class="has-text-grey is-size-7 cancel" @click="cancelEdit">キャンセル</a>
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { ICategory } from "@/domain/Qiita";
+
+@Component({
+  directives: {
+    focus: function(el, binding) {
+      if (binding.value) {
+        el.focus();
+      }
+    }
+  }
+})
+export default class CreateCategory extends Vue {
+  editing: boolean = false;
+
+  cancelEdit() {
+    this.editing = false;
+  }
+
+  saveCategory() {
+    this.editing = false;
+  }
+}
+</script>
+
+<style scoped>
+.cancel {
+  float: right;
+}
+</style>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -2,6 +2,7 @@
   <aside class="submenu menu">
     <SideMenuSearch/>
     <SideMenuList :categories="categories"/>
+    <CreateCategory />
   </aside>
 </template>
 
@@ -9,12 +10,14 @@
 import { Component, Vue, Prop } from "vue-property-decorator";
 import SideMenuSearch from "@/components/SideMenuSearch.vue";
 import SideMenuList from "@/components/SideMenuList.vue";
+import CreateCategory from "@/components/CreateCategory.vue";
 import { ICategory } from "@/domain/Qiita";
 
 @Component({
   components: {
     SideMenuSearch,
-    SideMenuList
+    SideMenuList,
+    CreateCategory
   }
 })
 export default class SideMenu extends Vue {

--- a/src/components/SideMenuList.vue
+++ b/src/components/SideMenuList.vue
@@ -4,18 +4,11 @@
       カテゴリ一覧
     </p>
     <ul class="menu-list">
-      <li
+      <Category
         v-for="category in categories"
         :key="category.id"
-      >
-        <a
-          :data-category="category.id"
-          @click="clickHandle"
-          :class="`${isActive(category.id) && 'is-active'}`"
-        >
-          {{ category.name }}
-        </a>
-      </li>
+        :category="category"
+      />
     </ul>
   </section>
 </template>
@@ -23,21 +16,16 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/Qiita";
+import Category from "@/components/Category.vue";
 
-@Component
+@Component({
+  components: {
+    Category
+  }
+})
 export default class SideMenuList extends Vue {
   @Prop()
   categories!: ICategory[];
-
-  clickHandle(event: any) {
-    // TODO カテゴリが選択済みの場合、何もしない
-    // TODO 選択されたカテゴリの記事を表示する
-    console.log(`${event.target.dataset.category} clicked!!`);
-  }
-
-  isActive(id: ICategory["id"]) {
-    return id === 1;
-  }
 }
 </script>
 

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -3,10 +3,10 @@
     <Header />
     <main class="container">
       <div class="columns">
-        <div class="column is-2">
+        <div class="column is-3">
           <SideMenu :categories="categories" />
         </div>
-        <div class="column is-10">
+        <div class="column is-9">
           <MediaList :qiitaItems="qiitaItems" />
           <Pagination />
         </div>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/85

# Doneの定義
- カテゴリ登録ページが作成されていること

# スクリーンショット
<img width="583" alt="2018-11-10 19 39 31" src="https://user-images.githubusercontent.com/32682645/48300423-79348780-e520-11e8-8fc9-e85c629bd8f1.png">

# 変更点概要

## 仕様的変更点概要
- カテゴリの作成
  `カテゴリを追加`ボタンを作成。ボタン押下でInput要素を表示する。
- カテゴリの編集/削除
  `編集`ボタンを作成。ボタン押下でInput要素を表示。
  `削除`ボタン押下で、カテゴリを削除する。

# 補足情報
レイアウトの微調整については、別のIssueで対応する。