### PR TITLE
ログイン状態によってHeaderの表示を切り替える

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -16,7 +16,7 @@
           </a>
         </div>
         <div class="navbar-menu" :class="{ 'is-active': isMenuActive }">
-          <div class="navbar-end" v-if="!isLogin">
+          <div class="navbar-end" v-if="!isLoggedIn">
             <div class="navbar-item">
               <a href="/login" class="has-text-grey">ログイン</a>
             </div>
@@ -46,7 +46,7 @@ const QiitaGetter = namespace("QiitaModule", Getter);
 @Component
 export default class AppHeader extends Vue {
   @QiitaGetter
-  isLogin!: LoginState["isLogin"];
+  isLoggedIn!: LoginState["isLoggedIn"];
 
   isMenuActive: boolean = false;
 

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -6,11 +6,28 @@
           <a class="navbar-item" href="/"
             ><p class="is-size-5 has-text-black">Qiita Stocker</p></a
           >
+          <a
+            role="button"
+            class="navbar-burger"
+            :class="{ 'is-active': isMenuActive }"
+            @click="menuToggle();"
+          >
+            <span></span> <span></span> <span></span>
+          </a>
         </div>
-        <div class="navbar-menu is-active">
-          <div class="navbar-end">
+        <div class="navbar-menu" :class="{ 'is-active': isMenuActive }">
+          <div class="navbar-end" v-if="!isLogin">
             <div class="navbar-item">
-              <a href="/login" class="button">ログイン</a>
+              <a href="/login" class="has-text-grey">ログイン</a>
+            </div>
+          </div>
+          <div class="navbar-end" v-else>
+            <div class="navbar-item has-dropdown is-hoverable">
+              <a class="navbar-link">アカウント</a>
+              <div class="navbar-dropdown is-right">
+                <a class="navbar-item" href="/cancel">設定</a>
+                <a class="navbar-item">ログアウト</a>
+              </div>
             </div>
           </div>
         </div>
@@ -21,9 +38,22 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import { Getter, namespace } from "vuex-class";
+import { LoginState } from "@/types/login";
+
+const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
-export default class AppHeader extends Vue {}
+export default class AppHeader extends Vue {
+  @QiitaGetter
+  isLogin!: LoginState["isLogin"];
+
+  isMenuActive: boolean = false;
+
+  menuToggle() {
+    this.isMenuActive = !this.isMenuActive;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -61,7 +61,7 @@ const state: LoginState = {
   authorizationCode: "",
   accessToken: "",
   permanentId: "",
-  isLogin: true
+  isLoggedIn: true
 };
 
 const getters: GetterTree<LoginState, RootState> = {
@@ -74,8 +74,8 @@ const getters: GetterTree<LoginState, RootState> = {
   permanentId: (state): LoginState["permanentId"] => {
     return state.permanentId;
   },
-  isLogin: (state): LoginState["isLogin"] => {
-    return state.isLogin;
+  isLoggedIn: (state): LoginState["isLoggedIn"] => {
+    return state.isLoggedIn;
   }
 };
 

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -61,7 +61,7 @@ const state: LoginState = {
   authorizationCode: "",
   accessToken: "",
   permanentId: "",
-  isLogin: false
+  isLogin: true
 };
 
 const getters: GetterTree<LoginState, RootState> = {
@@ -73,6 +73,9 @@ const getters: GetterTree<LoginState, RootState> = {
   },
   permanentId: (state): LoginState["permanentId"] => {
     return state.permanentId;
+  },
+  isLogin: (state): LoginState["isLogin"] => {
+    return state.isLogin;
   }
 };
 

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -60,7 +60,8 @@ interface IFetchUserPayload {
 const state: LoginState = {
   authorizationCode: "",
   accessToken: "",
-  permanentId: ""
+  permanentId: "",
+  isLogin: false
 };
 
 const getters: GetterTree<LoginState, RootState> = {

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -2,5 +2,5 @@ export interface LoginState {
   authorizationCode: string;
   accessToken: string;
   permanentId: string;
-  isLogin: boolean;
+  isLoggedIn: boolean;
 }

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -2,4 +2,5 @@ export interface LoginState {
   authorizationCode: string;
   accessToken: string;
   permanentId: string;
+  isLogin: boolean;
 }

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -22,7 +22,8 @@ describe("Cancel.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
-      permanentId: ""
+      permanentId: "",
+      isLogin: true
     };
 
     actions = {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -23,7 +23,7 @@ describe("Cancel.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLogin: true
+      isLoggedIn: true
     };
 
     actions = {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -22,7 +22,8 @@ describe("Login.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
-      permanentId: ""
+      permanentId: "",
+      isLogin: false
     };
 
     actions = {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -23,7 +23,7 @@ describe("Login.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLogin: false
+      isLoggedIn: false
     };
 
     actions = {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -18,7 +18,8 @@ describe("QiitaModule", () => {
       state = {
         authorizationCode: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
         accessToken: "72d79c218c16c65b8076c7de8ef6ec55504ca6a0",
-        permanentId: "1"
+        permanentId: "1",
+        isLogin: false
       };
     });
 
@@ -51,7 +52,8 @@ describe("QiitaModule", () => {
       state = {
         authorizationCode: "",
         accessToken: "",
-        permanentId: ""
+        permanentId: "",
+        isLogin: false
       };
     });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -19,7 +19,7 @@ describe("QiitaModule", () => {
         authorizationCode: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
         accessToken: "72d79c218c16c65b8076c7de8ef6ec55504ca6a0",
         permanentId: "1",
-        isLogin: false
+        isLoggedIn: false
       };
     });
 
@@ -53,7 +53,7 @@ describe("QiitaModule", () => {
         authorizationCode: "",
         accessToken: "",
         permanentId: "",
-        isLogin: false
+        isLoggedIn: false
       };
     });
 

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -23,7 +23,7 @@ describe("SignUp.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLogin: false
+      isLoggedIn: false
     };
 
     actions = {

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -22,7 +22,8 @@ describe("SignUp.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
-      permanentId: ""
+      permanentId: "",
+      isLogin: false
     };
 
     actions = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/74

# Doneの定義
- ログイン状態によってHeaderの表示が切り替わること

# スクリーンショット
<img width="1225" alt="2018-11-11 23 50 37" src="https://user-images.githubusercontent.com/32682645/48314444-e6bde200-e60c-11e8-9c68-78d9031e1c34.png">
<img width="1212" alt="2018-11-11 23 51 22" src="https://user-images.githubusercontent.com/32682645/48314447-ee7d8680-e60c-11e8-8340-d68c41509c7c.png">


# 変更点概要

## 仕様的変更点概要
- ログイン状態によってヘッダーの表示を切り替え
- タッチデバイスの場合、ハンバーガーメニューを表示するように修正

## 技術的変更点概要
ログイン状態を管理するため、QiitaModuleのstateに`isLogin`を追加。