### PR TITLE
CreateCategoryコンポーネンにStoreのアクションを呼び出す処理を追加

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,11 +13,5 @@ module.exports = {
   testMatch: [
     "**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)"
   ],
-  testURL: "http://localhost/",
-  globals: {
-    "ts-jest": {
-      pathRegex: /\.(spec|test)\.ts$/,
-      diagnostics: false
-    }
-  }
+  testURL: "http://localhost/"
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,11 @@ module.exports = {
   testMatch: [
     "**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)"
   ],
-  testURL: "http://localhost/"
+  testURL: "http://localhost/",
+  globals: {
+    "ts-jest": {
+      pathRegex: /\.(spec|test)\.ts$/,
+      diagnostics: false
+    }
+  }
 };

--- a/src/components/CreateCategory.vue
+++ b/src/components/CreateCategory.vue
@@ -5,14 +5,23 @@
     </button>
     <div v-show="editing">
       <div class="field">
-        <input class="input" type="text" v-focus="editing" />
+        <input
+          class="input"
+          type="text"
+          v-focus="editing"
+          v-model="category"
+          @input="setCategory"
+        />
       </div>
       <div class="field">
         <p class="control">
-          <button class="button is-small is-danger" @click="saveCategory">
+          <button
+            class="button is-small is-danger"
+            @click="onClickSaveCategory"
+          >
             カテゴリを追加
           </button>
-          <a class="has-text-grey is-size-7 cancel" @click="cancelEdit"
+          <a class="has-text-grey is-size-7 cancel" @click="doneEdit"
             >キャンセル</a
           >
         </p>
@@ -36,13 +45,21 @@ import { ICategory } from "@/domain/Qiita";
 })
 export default class CreateCategory extends Vue {
   editing: boolean = false;
+  category: string = "";
 
-  cancelEdit() {
+  doneEdit() {
+    this.category = "";
     this.editing = false;
   }
 
-  saveCategory() {
-    this.editing = false;
+  onClickSaveCategory() {
+    // TODO バリデーションを追加する
+    this.$emit("clickSaveCategory", this.category);
+    this.doneEdit();
+  }
+
+  setCategory(event: any) {
+    this.category = event.target.value;
   }
 }
 </script>

--- a/src/components/CreateCategory.vue
+++ b/src/components/CreateCategory.vue
@@ -32,7 +32,6 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { ICategory } from "@/domain/Qiita";
 
 @Component({
   directives: {

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="submenu menu">
     <SideMenuSearch /> <SideMenuList :categories="categories" />
-    <CreateCategory />
+    <CreateCategory @clickSaveCategory="onClickSaveCategory" />
   </aside>
 </template>
 
@@ -22,5 +22,9 @@ import { ICategory } from "@/domain/Qiita";
 export default class SideMenu extends Vue {
   @Prop()
   categories!: ICategory[];
+
+  onClickSaveCategory(category: string) {
+    this.$emit("clickSaveCategory", category);
+  }
 }
 </script>

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -3,7 +3,12 @@
     <AppHeader />
     <main class="container">
       <div class="columns">
-        <div class="column is-3"><SideMenu :categories="categories" /></div>
+        <div class="column is-3">
+          <SideMenu
+            :categories="categories"
+            @clickSaveCategory="onClickSaveCategory"
+          />
+        </div>
         <div class="column is-9">
           <MediaList :qiitaItems="qiitaItems" /> <Pagination />
         </div>
@@ -14,11 +19,15 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import { Action, namespace } from "vuex-class";
+
 import AppHeader from "@/components/AppHeader.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import MediaList from "@/components/MediaList.vue";
 import Pagination from "@/components/Pagination.vue";
 import { ICategory, IQiitaItem } from "@/domain/Qiita";
+
+const QiitaAction = namespace("QiitaModule", Action);
 
 @Component({
   components: {
@@ -70,6 +79,13 @@ export default class Account extends Vue {
       profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
     }
   ];
+
+  @QiitaAction
+  saveCategory!: (category: string) => void;
+
+  onClickSaveCategory(category: string) {
+    this.saveCategory(category);
+  }
 }
 </script>
 

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -249,6 +249,10 @@ const actions: ActionTree<LoginState, RootState> = {
       });
       return;
     }
+  },
+  saveCategory: async ({ commit }, category: string) => {
+    // TODO QiitaStockerAPIクラスにカテゴリ作成APIへのリクエスト処理を作成し、それを呼び出す
+    console.log(category);
   }
 };
 

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -1,0 +1,82 @@
+import { shallowMount, mount, createLocalVue, config } from "@vue/test-utils";
+import Vuex from "vuex";
+import { QiitaModule } from "@/store/modules/Qiita";
+import Account from "@/pages/Account.vue";
+import SideMenu from "@/components/SideMenu.vue";
+import { LoginState } from "@/types/login";
+import VueRouter from "vue-router";
+
+config.logModifiedComponents = false;
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+const router = new VueRouter();
+
+describe("Account.vue", () => {
+  let store: any;
+  let state: LoginState;
+  let actions: any;
+
+  beforeAll(() => {
+    state = {
+      authorizationCode: "",
+      accessToken: "",
+      permanentId: "",
+      isLoggedIn: true
+    };
+
+    actions = {
+      saveCategory: jest.fn()
+    };
+
+    store = new Vuex.Store({
+      modules: {
+        QiitaModule: {
+          namespaced: true,
+          state,
+          actions,
+          getters: QiitaModule.getters
+        }
+      }
+    });
+  });
+
+  describe("methods", () => {
+    it('calls store action "saveCategory" on onClickSaveCategory()', () => {
+      const wrapper = shallowMount(Account, { store, localVue, router });
+      const inputtedCategory = "inputtedCategory";
+
+      // @ts-ignore
+      wrapper.vm.onClickSaveCategory(inputtedCategory);
+
+      expect(actions.saveCategory).toHaveBeenCalledWith(
+        expect.anything(),
+        inputtedCategory,
+        undefined
+      );
+    });
+  });
+
+  // mountによる結合テスト
+  describe("template", () => {
+    it("should call onClickSaveCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(Account, { store, localVue, router });
+
+      wrapper.setMethods({
+        onClickSaveCategory: mock
+      });
+
+      const sideMenu = wrapper.find(SideMenu);
+      const inputtedCategory = "inputtedCategory";
+
+      // @ts-ignore
+      sideMenu.vm.onClickSaveCategory(inputtedCategory);
+
+      expect(mock).toHaveBeenCalledWith(inputtedCategory);
+    });
+  });
+});

--- a/tests/unit/CreateCategory.spec.ts
+++ b/tests/unit/CreateCategory.spec.ts
@@ -1,0 +1,40 @@
+import { shallowMount } from "@vue/test-utils";
+import CreateCategory from "@/components/CreateCategory.vue";
+
+describe("CreateCategory.vue", () => {
+  describe("methods", () => {
+    it("should emit clickSaveCategory on onClickSaveCategory()", () => {
+      const wrapper = shallowMount(CreateCategory);
+      const inputtedCategory = "inputtedCategory";
+
+      // @ts-ignore
+      wrapper.vm.category = inputtedCategory;
+
+      // @ts-ignore
+      wrapper.vm.onClickSaveCategory();
+
+      expect(wrapper.emitted("clickSaveCategory")).toBeTruthy();
+      expect(wrapper.emitted("clickSaveCategory")[0][0]).toEqual(
+        inputtedCategory
+      );
+    });
+  });
+
+  describe("template", () => {
+    it("should call onClickSaveCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CreateCategory);
+
+      wrapper.setMethods({
+        onClickSaveCategory: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/SideMenu.spec.ts
+++ b/tests/unit/SideMenu.spec.ts
@@ -1,0 +1,45 @@
+import { shallowMount, mount, config } from "@vue/test-utils";
+import SideMenu from "@/components/SideMenu.vue";
+import CreateCategory from "@/components/CreateCategory.vue";
+
+config.logModifiedComponents = false;
+
+describe("SideMenu.vue", () => {
+  describe("methods", () => {
+    it("should emit clickSaveCategory on onClickSaveCategory()", () => {
+      const wrapper = shallowMount(SideMenu);
+      const inputtedCategory = "inputtedCategory";
+
+      // @ts-ignore
+      wrapper.vm.onClickSaveCategory(inputtedCategory);
+
+      expect(wrapper.emitted("clickSaveCategory")).toBeTruthy();
+      expect(wrapper.emitted("clickSaveCategory")[0][0]).toEqual(
+        inputtedCategory
+      );
+    });
+  });
+
+  // mountによる結合テスト
+  describe("template", () => {
+    it("should call onClickSaveCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(SideMenu);
+
+      wrapper.setMethods({
+        onClickSaveCategory: mock
+      });
+
+      const createCategory = wrapper.find(CreateCategory);
+      const inputtedCategory = "inputtedCategory";
+
+      // @ts-ignore
+      createCategory.vm.category = inputtedCategory;
+
+      // @ts-ignore
+      createCategory.vm.onClickSaveCategory();
+
+      expect(mock).toHaveBeenCalledWith(inputtedCategory);
+    });
+  });
+});


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/92

# Doneの定義
- `CreateCategory`コンポーネンからStoreのアクションを呼び出す処理が作成されていること

# 変更点概要

## 仕様的変更点概要
カテゴリを追加する際の動作を追加。

## 技術的変更点概要
### コンポーネントの機能追加
`CreateCategory`コンポーネントに、以下のケースの処理を追加。
- カテゴリを追加
- キャンセル

カテゴリ追加の処理は、$emitを使って上位のコンポーネントに委ねている。
実際にStoreのactionを呼び出す処理は、`Account`コンポーネントに追加している。

### テストを追加
コンポーネントのテストは2つの観点でテストしている。

- method
コンポーネントラッパーのvmプロパティから実行し、methodのテストを行う。

- template
mountによるコンポーネントの結合テスト。
子コンポーネントでイベントを発火させ、親コンポーネントの動作をテストする。

### テストについて補足1
TypeScriptのエラーを回避するために、`@ts-ignore`をエラー箇所に設定。

以下の通り、`jest.config.js`の設定を変更することでもエラーを回避できる。
https://huafu.github.io/ts-jest/user/config/diagnostics#advanced-configuration

`@ts-ignore`を個別に設定した場合、エディタのエラーも表示されないのでこちらを採用した。

### テストについて補足2
コンポーネントの警告が表示されるのを回避するため、テストに下記を追加。
`config.logModifiedComponents = false;`
https://vue-test-utils.vuejs.org/api/config.html#logmodifiedcomponents
https://qiita.com/kai_kou/items/7463b516c5895c1dcdba

# 補足情報
カテゴリ作成APIへのリクエスト処理は、別のPRにて対応する。