### PR TITLE
APIへのリクエスト処理を作成する

### DIFF
--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -23,6 +23,7 @@ export interface IQiitaStockerApi {
   issueLoginSession(
     request: IIssueLoginSessionRequest
   ): Promise<IIssueLoginSessionResponse>;
+  saveCategory(request: ISaveCategoryRequest): Promise<ISaveCategoryResponse>;
 }
 
 export interface IQiitaApi {
@@ -91,6 +92,17 @@ export interface ICancelAccountRequest {
   sessionId: string;
 }
 
+export interface ISaveCategoryRequest {
+  apiUrlBase: string;
+  name: string;
+  sessionId: string;
+}
+
+export interface ISaveCategoryResponse {
+  categoryId: string;
+  name: string;
+}
+
 interface IQiitaStockerErrorData {
   code: number;
   message: string;
@@ -152,6 +164,12 @@ export const cancelAccount = async (
   request: ICancelAccountRequest
 ): Promise<void> => {
   return await qiitaStockerApi.cancelAccount(request);
+};
+
+export const saveCategory = async (
+  request: ISaveCategoryRequest
+): Promise<ISaveCategoryResponse> => {
+  return await qiitaStockerApi.saveCategory(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -6,7 +6,9 @@ import {
   IIssueLoginSessionRequest,
   IIssueLoginSessionResponse,
   IQiitaStockerError,
-  ICancelAccountRequest
+  ICancelAccountRequest,
+  ISaveCategoryRequest,
+  ISaveCategoryResponse
 } from "@/domain/Qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -16,7 +18,10 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
     return await axios
       .post<ICreateAccountResponse>(
         `${request.apiUrlBase}/api/accounts`,
-        request,
+        {
+          permanentId: request.permanentId,
+          accessToken: request.accessToken
+        },
         {
           headers: {
             "Content-Type": "application/json"
@@ -52,9 +57,34 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
     return await axios
       .post<IIssueLoginSessionResponse>(
         `${request.apiUrlBase}/api/login-sessions`,
-        request,
+        {
+          permanentId: request.permanentId,
+          accessToken: request.accessToken
+        },
         {
           headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async saveCategory(
+    request: ISaveCategoryRequest
+  ): Promise<ISaveCategoryResponse> {
+    return await axios
+      .post<IIssueLoginSessionResponse>(
+        `${request.apiUrlBase}/api/categories`,
+        { name: request.name },
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`,
             "Content-Type": "application/json"
           }
         }

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -275,7 +275,6 @@ const actions: ActionTree<LoginState, RootState> = {
         name: saveCategoryResponse.name
       };
 
-      console.log(savedCategory);
       commit("addCategory", savedCategory);
     } catch (error) {
       router.push({

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Vuex, { GetterTree, MutationTree, ActionTree, Module } from "vuex";
-import { LoginState } from "@/types/login";
+import { LoginState, Category } from "@/types/login";
 import { RootState } from "@/store";
 import {
   requestToAuthorizationServer,
@@ -64,7 +64,8 @@ const state: LoginState = {
   authorizationCode: "",
   accessToken: "",
   permanentId: "",
-  isLoggedIn: true
+  isLoggedIn: true,
+  categories: []
 };
 
 const getters: GetterTree<LoginState, RootState> = {
@@ -91,6 +92,9 @@ const mutations: MutationTree<LoginState> = {
   },
   savePermanentId: (state, permanentId: string) => {
     state.permanentId = permanentId;
+  },
+  addCategory: (state, category: Category) => {
+    state.categories.push(category);
   }
 };
 
@@ -265,9 +269,14 @@ const actions: ActionTree<LoginState, RootState> = {
       const saveCategoryResponse: ISaveCategoryResponse = await saveCategory(
         saveCategoryRequest
       );
-      console.log(saveCategoryResponse);
 
-      // TODO stateにレスポンスのカテゴリーを保存する
+      const savedCategory: Category = {
+        id: saveCategoryResponse.categoryId,
+        name: saveCategoryResponse.name
+      };
+
+      console.log(savedCategory);
+      commit("addCategory", savedCategory);
     } catch (error) {
       router.push({
         name: "error",

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -25,6 +25,9 @@ import {
   issueLoginSession,
   ICancelAccountRequest,
   cancelAccount,
+  saveCategory,
+  ISaveCategoryRequest,
+  ISaveCategoryResponse,
   unauthorizedMessage
 } from "@/domain/Qiita";
 import uuid from "uuid";
@@ -251,8 +254,27 @@ const actions: ActionTree<LoginState, RootState> = {
     }
   },
   saveCategory: async ({ commit }, category: string) => {
-    // TODO QiitaStockerAPIクラスにカテゴリ作成APIへのリクエスト処理を作成し、それを呼び出す
-    console.log(category);
+    try {
+      const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+      const saveCategoryRequest: ISaveCategoryRequest = {
+        apiUrlBase: apiUrlBase(),
+        name: category,
+        sessionId: sessionId
+      };
+
+      const saveCategoryResponse: ISaveCategoryResponse = await saveCategory(
+        saveCategoryRequest
+      );
+      console.log(saveCategoryResponse);
+
+      // TODO stateにレスポンスのカテゴリーを保存する
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
   }
 };
 

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -3,4 +3,10 @@ export interface LoginState {
   accessToken: string;
   permanentId: string;
   isLoggedIn: boolean;
+  categories: Category[];
+}
+
+export interface Category {
+  id: string;
+  name: string;
 }

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -25,7 +25,8 @@ describe("Account.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLoggedIn: true
+      isLoggedIn: true,
+      categories: []
     };
 
     actions = {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -23,7 +23,8 @@ describe("Cancel.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLoggedIn: true
+      isLoggedIn: true,
+      categories: []
     };
 
     actions = {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -23,7 +23,8 @@ describe("Login.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLoggedIn: false
+      isLoggedIn: false,
+      categories: []
     };
 
     actions = {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -19,7 +19,8 @@ describe("QiitaModule", () => {
         authorizationCode: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
         accessToken: "72d79c218c16c65b8076c7de8ef6ec55504ca6a0",
         permanentId: "1",
-        isLoggedIn: false
+        isLoggedIn: false,
+        categories: []
       };
     });
 
@@ -53,7 +54,8 @@ describe("QiitaModule", () => {
         authorizationCode: "",
         accessToken: "",
         permanentId: "",
-        isLoggedIn: false
+        isLoggedIn: false,
+        categories: []
       };
     });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -1,10 +1,11 @@
-import { LoginState } from "@/types/login";
+import { LoginState, Category } from "@/types/login";
 import { QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
 import {
   IIssueAccessTokensResponse,
   IFetchAuthenticatedUserResponse,
-  IAuthorizationResponse
+  IAuthorizationResponse,
+  ISaveCategoryResponse
 } from "@/domain/Qiita";
 
 jest.mock("@/domain/Qiita");
@@ -90,6 +91,18 @@ describe("QiitaModule", () => {
       wrapper(QiitaModule.mutations);
 
       expect(state.permanentId).toEqual("1");
+    });
+
+    it("should be able to add categories", () => {
+      const category: Category = {
+        id: "1",
+        name: "テストカテゴリー"
+      };
+      const wrapper = (mutations: any) =>
+        mutations.addCategory(state, category);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.categories[0]).toEqual(category);
     });
   });
 
@@ -199,6 +212,34 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([]);
+    });
+
+    it("should be able to save category", async () => {
+      const categoryId = "1";
+      const categoryName: string = "テストカテゴリー";
+
+      const mockPostResponse: { data: ISaveCategoryResponse } = {
+        data: {
+          categoryId: categoryId,
+          name: categoryName
+        }
+      };
+
+      const mockAxios: any = axios;
+      mockAxios.post.mockResolvedValue(mockPostResponse);
+
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) =>
+        actions.saveCategory({ commit }, categoryName);
+      await wrapper(QiitaModule.actions);
+
+      const savedCategory: Category = {
+        id: categoryId,
+        name: categoryName
+      };
+
+      expect(commit.mock.calls).toEqual([["addCategory", savedCategory]]);
     });
   });
 });

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -23,7 +23,8 @@ describe("SignUp.vue", () => {
       authorizationCode: "",
       accessToken: "",
       permanentId: "",
-      isLoggedIn: false
+      isLoggedIn: false,
+      categories: []
     };
 
     actions = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/92

# Doneの定義
- カテゴリ作成APIとフロントエンドが通信できていること

# 変更点概要

## 技術的変更点概要
カテゴリ作成APIへのリクエスト処理を作成。
stateに`categories[]`を追加し、レスポンス結果を保存している。
Moduleのテストに、mutationとactionのテストケースを追加。

今回のIssueとは関係ないが、`QiitaStockerApi`クラスの`createAccount()`、`issueLoginSession ()`にてPOSTデータに不要なパラメータが指定されていたため修正した。
https://github.com/nekochans/qiita-stocker-frontend/pull/104/files#diff-c02d016c6ef47e70eb4bff043908d23cR21
https://github.com/nekochans/qiita-stocker-frontend/pull/104/files#diff-c02d016c6ef47e70eb4bff043908d23cR60