### PR TITLE
Accountコンポーネントにstoreのactionを呼び出す処理を作成する

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -39,14 +39,14 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Getter, namespace } from "vuex-class";
-import { LoginState } from "@/types/login";
+import { ILoginState } from "@/types/login";
 
 const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
 export default class AppHeader extends Vue {
   @QiitaGetter
-  isLoggedIn!: LoginState["isLoggedIn"];
+  isLoggedIn!: ILoginState["isLoggedIn"];
 
   isMenuActive: boolean = false;
 

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-import { ICategory } from "@/domain/Qiita";
+import { ICategory } from "@/types/login";
 
 @Component({
   directives: {
@@ -59,7 +59,7 @@ export default class Category extends Vue {
   }
 
   isActive(id: ICategory["id"]) {
-    return id === 1;
+    return id === "1";
   }
 
   doneEdit() {

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -10,7 +10,7 @@ import { Component, Vue, Prop } from "vue-property-decorator";
 import SideMenuSearch from "@/components/SideMenuSearch.vue";
 import SideMenuList from "@/components/SideMenuList.vue";
 import CreateCategory from "@/components/CreateCategory.vue";
-import { ICategory } from "@/domain/Qiita";
+import { ICategory } from "@/types/login";
 
 @Component({
   components: {

--- a/src/components/SideMenuList.vue
+++ b/src/components/SideMenuList.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-import { ICategory } from "@/domain/Qiita";
+import { ICategory } from "@/types/login";
 import Category from "@/components/Category.vue";
 
 @Component({

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -113,12 +113,6 @@ export interface IQiitaStockerError extends AxiosError {
 }
 
 // TODO 適切な値に修正する
-export interface ICategory {
-  id: number;
-  name: string;
-}
-
-// TODO 適切な値に修正する
 export interface IQiitaItem {
   id: string;
   title: string;

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -19,15 +19,17 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { Action, namespace } from "vuex-class";
+import { Getter, Action, namespace } from "vuex-class";
 
 import AppHeader from "@/components/AppHeader.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import MediaList from "@/components/MediaList.vue";
 import Pagination from "@/components/Pagination.vue";
-import { ICategory, IQiitaItem } from "@/domain/Qiita";
+import { IQiitaItem } from "@/domain/Qiita";
+import { ICategory } from "@/types/login";
 
 const QiitaAction = namespace("QiitaModule", Action);
+const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component({
   components: {
@@ -38,21 +40,6 @@ const QiitaAction = namespace("QiitaModule", Action);
   }
 })
 export default class Account extends Vue {
-  categories: ICategory[] = [
-    {
-      id: 1,
-      name: "設計"
-    },
-    {
-      id: 2,
-      name: "テスト"
-    },
-    {
-      id: 3,
-      name: "ドメイン駆動設計"
-    }
-  ];
-
   qiitaItems: IQiitaItem[] = [
     {
       id: "c0a2609ae61a72dcc60f",
@@ -80,11 +67,23 @@ export default class Account extends Vue {
     }
   ];
 
+  @QiitaGetter
+  categories!: ICategory[];
+
   @QiitaAction
   saveCategory!: (category: string) => void;
 
+  @QiitaAction
+  fetchCategory!: () => ICategory[];
+
   onClickSaveCategory(category: string) {
     this.saveCategory(category);
+  }
+
+  created() {
+    if (!this.categories.length) {
+      this.fetchCategory();
+    }
   }
 }
 </script>

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -81,6 +81,10 @@ export default class Account extends Vue {
   }
 
   created() {
+    this.initializeCategory();
+  }
+
+  initializeCategory() {
     if (!this.categories.length) {
       this.fetchCategory();
     }

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Vuex, { GetterTree, MutationTree, ActionTree, Module } from "vuex";
-import { LoginState, Category } from "@/types/login";
+import { ILoginState, ICategory } from "@/types/login";
 import { RootState } from "@/store";
 import {
   requestToAuthorizationServer,
@@ -60,7 +60,7 @@ interface IFetchUserPayload {
   accountAction: "signUp" | "login";
 }
 
-const state: LoginState = {
+const state: ILoginState = {
   authorizationCode: "",
   accessToken: "",
   permanentId: "",
@@ -68,22 +68,25 @@ const state: LoginState = {
   categories: []
 };
 
-const getters: GetterTree<LoginState, RootState> = {
-  authorizationCode: (state): LoginState["authorizationCode"] => {
+const getters: GetterTree<ILoginState, RootState> = {
+  authorizationCode: (state): ILoginState["authorizationCode"] => {
     return state.authorizationCode;
   },
-  accessToken: (state): LoginState["accessToken"] => {
+  accessToken: (state): ILoginState["accessToken"] => {
     return state.accessToken;
   },
-  permanentId: (state): LoginState["permanentId"] => {
+  permanentId: (state): ILoginState["permanentId"] => {
     return state.permanentId;
   },
-  isLoggedIn: (state): LoginState["isLoggedIn"] => {
+  isLoggedIn: (state): ILoginState["isLoggedIn"] => {
     return state.isLoggedIn;
+  },
+  categories: (state): ILoginState["categories"] => {
+    return state.categories;
   }
 };
 
-const mutations: MutationTree<LoginState> = {
+const mutations: MutationTree<ILoginState> = {
   saveAuthorizationCode: (state, authorizationCode: string) => {
     state.authorizationCode = authorizationCode;
   },
@@ -93,12 +96,15 @@ const mutations: MutationTree<LoginState> = {
   savePermanentId: (state, permanentId: string) => {
     state.permanentId = permanentId;
   },
-  addCategory: (state, category: Category) => {
+  saveCategory: (state, categories: ICategory[]) => {
+    state.categories = categories;
+  },
+  addCategory: (state, category: ICategory) => {
     state.categories.push(category);
   }
 };
 
-const actions: ActionTree<LoginState, RootState> = {
+const actions: ActionTree<ILoginState, RootState> = {
   signUp: ({ commit }) => {
     localStorage.save(STORAGE_KEY_ACCOUNT_ACTION, "signUp");
     requestToAuthorizationServer(createAuthRequestParam());
@@ -270,12 +276,41 @@ const actions: ActionTree<LoginState, RootState> = {
         saveCategoryRequest
       );
 
-      const savedCategory: Category = {
+      const savedCategory: ICategory = {
         id: saveCategoryResponse.categoryId,
         name: saveCategoryResponse.name
       };
 
       commit("addCategory", savedCategory);
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
+  },
+  fetchCategory: async ({ commit }) => {
+    try {
+      // TODO カテゴリ取得APIからカテゴリ一覧を取得する
+
+      // 仮実装として仮のカテゴリ一覧を用意
+      const categories: ICategory[] = [
+        {
+          id: "1",
+          name: "設計"
+        },
+        {
+          id: "2",
+          name: "テスト"
+        },
+        {
+          id: "3",
+          name: "ドメイン駆動設計"
+        }
+      ];
+
+      commit("saveCategory", categories);
     } catch (error) {
       router.push({
         name: "error",
@@ -298,7 +333,7 @@ const createAuthRequestParam = (): IAuthorizationRequest => {
   return authorizationRequest;
 };
 
-export const QiitaModule: Module<LoginState, RootState> = {
+export const QiitaModule: Module<ILoginState, RootState> = {
   namespaced: true,
   state,
   mutations,

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,12 +1,12 @@
-export interface LoginState {
+export interface ILoginState {
   authorizationCode: string;
   accessToken: string;
   permanentId: string;
   isLoggedIn: boolean;
-  categories: Category[];
+  categories: ICategory[];
 }
 
-export interface Category {
+export interface ICategory {
   id: string;
   name: string;
 }

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -30,7 +30,8 @@ describe("Account.vue", () => {
     };
 
     actions = {
-      saveCategory: jest.fn()
+      saveCategory: jest.fn(),
+      fetchCategory: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -58,6 +59,15 @@ describe("Account.vue", () => {
         inputtedCategory,
         undefined
       );
+    });
+
+    it('calls store action "fetchCategory" on initializeCategory()', () => {
+      const wrapper = shallowMount(Account, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.initializeCategory();
+
+      expect(actions.fetchCategory).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -3,7 +3,7 @@ import Vuex from "vuex";
 import { QiitaModule } from "@/store/modules/Qiita";
 import Account from "@/pages/Account.vue";
 import SideMenu from "@/components/SideMenu.vue";
-import { LoginState } from "@/types/login";
+import { ILoginState } from "@/types/login";
 import VueRouter from "vue-router";
 
 config.logModifiedComponents = false;
@@ -17,7 +17,7 @@ const router = new VueRouter();
 
 describe("Account.vue", () => {
   let store: any;
-  let state: LoginState;
+  let state: ILoginState;
   let actions: any;
 
   beforeAll(() => {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -3,7 +3,7 @@ import Vuex from "vuex";
 import Cancel from "../../src/pages/cencel/Cancel.vue";
 import { QiitaModule } from "@/store/modules/Qiita";
 
-import { LoginState } from "@/types/login";
+import { ILoginState } from "@/types/login";
 import VueRouter from "vue-router";
 
 const localVue = createLocalVue();
@@ -15,7 +15,7 @@ const router = new VueRouter();
 
 describe("Cancel.vue", () => {
   let store: any;
-  let state: LoginState;
+  let state: ILoginState;
   let actions: any;
 
   it('calls store action "cancel" when button is clicked', () => {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -3,7 +3,7 @@ import Vuex from "vuex";
 import Login from "../../src/pages/Login.vue";
 import { QiitaModule } from "@/store/modules/Qiita";
 
-import { LoginState } from "@/types/login";
+import { ILoginState } from "@/types/login";
 import VueRouter from "vue-router";
 
 const localVue = createLocalVue();
@@ -15,7 +15,7 @@ const router = new VueRouter();
 
 describe("Login.vue", () => {
   let store: any;
-  let state: LoginState;
+  let state: ILoginState;
   let actions: any;
 
   it('calls store action "login" when button is clicked', () => {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -1,4 +1,4 @@
-import { LoginState, Category } from "@/types/login";
+import { ILoginState, ICategory } from "@/types/login";
 import { QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
 import {
@@ -13,7 +13,7 @@ jest.mock("axios");
 
 describe("QiitaModule", () => {
   describe("getters", () => {
-    let state: LoginState;
+    let state: ILoginState;
 
     beforeEach(() => {
       state = {
@@ -27,28 +27,28 @@ describe("QiitaModule", () => {
 
     it("should be able to get authorizationCode", () => {
       const wrapper = (getters: any) => getters.authorizationCode(state);
-      const authorizationCode: LoginState = wrapper(QiitaModule.getters);
+      const authorizationCode: ILoginState = wrapper(QiitaModule.getters);
 
       expect(authorizationCode).toEqual(state.authorizationCode);
     });
 
     it("should be able to get accessToken", () => {
       const wrapper = (getters: any) => getters.accessToken(state);
-      const accessToken: LoginState = wrapper(QiitaModule.getters);
+      const accessToken: ILoginState = wrapper(QiitaModule.getters);
 
       expect(accessToken).toEqual(state.accessToken);
     });
 
     it("should be able to get permanentId", () => {
       const wrapper = (getters: any) => getters.permanentId(state);
-      const permanentId: LoginState = wrapper(QiitaModule.getters);
+      const permanentId: ILoginState = wrapper(QiitaModule.getters);
 
       expect(permanentId).toEqual(state.permanentId);
     });
   });
 
   describe("mutations", () => {
-    let state: LoginState;
+    let state: ILoginState;
 
     beforeEach(() => {
       state = {
@@ -94,7 +94,7 @@ describe("QiitaModule", () => {
     });
 
     it("should be able to add categories", () => {
-      const category: Category = {
+      const category: ICategory = {
         id: "1",
         name: "テストカテゴリー"
       };
@@ -234,7 +234,7 @@ describe("QiitaModule", () => {
         actions.saveCategory({ commit }, categoryName);
       await wrapper(QiitaModule.actions);
 
-      const savedCategory: Category = {
+      const savedCategory: ICategory = {
         id: categoryId,
         name: categoryName
       };

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -27,23 +27,38 @@ describe("QiitaModule", () => {
 
     it("should be able to get authorizationCode", () => {
       const wrapper = (getters: any) => getters.authorizationCode(state);
-      const authorizationCode: ILoginState = wrapper(QiitaModule.getters);
+      const authorizationCode: ILoginState["authorizationCode"] = wrapper(
+        QiitaModule.getters
+      );
 
       expect(authorizationCode).toEqual(state.authorizationCode);
     });
 
     it("should be able to get accessToken", () => {
       const wrapper = (getters: any) => getters.accessToken(state);
-      const accessToken: ILoginState = wrapper(QiitaModule.getters);
+      const accessToken: ILoginState["accessToken"] = wrapper(
+        QiitaModule.getters
+      );
 
       expect(accessToken).toEqual(state.accessToken);
     });
 
     it("should be able to get permanentId", () => {
       const wrapper = (getters: any) => getters.permanentId(state);
-      const permanentId: ILoginState = wrapper(QiitaModule.getters);
+      const permanentId: ILoginState["permanentId"] = wrapper(
+        QiitaModule.getters
+      );
 
       expect(permanentId).toEqual(state.permanentId);
+    });
+
+    it("should be able to get categories", () => {
+      const wrapper = (getters: any) => getters.categories(state);
+      const categories: ILoginState["categories"] = wrapper(
+        QiitaModule.getters
+      );
+
+      expect(categories).toEqual(state.categories);
     });
   });
 
@@ -91,6 +106,28 @@ describe("QiitaModule", () => {
       wrapper(QiitaModule.mutations);
 
       expect(state.permanentId).toEqual("1");
+    });
+
+    it("should be able to save categories", () => {
+      const categories: ICategory[] = [
+        {
+          id: "1",
+          name: "テストカテゴリー1"
+        },
+        {
+          id: "2",
+          name: "テストカテゴリー2"
+        },
+        {
+          id: "3",
+          name: "テストカテゴリー3"
+        }
+      ];
+      const wrapper = (mutations: any) =>
+        mutations.saveCategory(state, categories);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.categories).toEqual(categories);
     });
 
     it("should be able to add categories", () => {

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -3,7 +3,7 @@ import Vuex from "vuex";
 import SignUp from "../../src/pages/SignUp.vue";
 import { QiitaModule } from "@/store/modules/Qiita";
 
-import { LoginState } from "@/types/login";
+import { ILoginState } from "@/types/login";
 import VueRouter from "vue-router";
 
 const localVue = createLocalVue();
@@ -15,7 +15,7 @@ const router = new VueRouter();
 
 describe("SignUp.vue", () => {
   let store: any;
-  let state: LoginState;
+  let state: ILoginState;
   let actions: any;
 
   it('calls store action "signUp" when button is clicked', () => {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/93

# Doneの定義
- Accountコンポーネントが作成された際に、storeのactionが呼び出されていること

# 変更点概要

## 仕様的変更点概要
APIから取得したカテゴリ一覧を表示する処理を追加

## 技術的変更点概要
- `Account`コンポーネントに、カテゴリ一覧を取得して表示する処理を追加
- QiitaModuleにカテゴリ取得処理を仮実装
- `Account`コンポーネントとQiitaModuleのテストケースを追加

このIssueとは直接関係ないが、以下についても実施。

- カテゴリのInterfaceが`src/domain/Qiita.ts`と`src/types/login.ts`の両方に定義されていたので、
ドメインのInterface削除
- `src/types/login.ts`のInterfaceの名前を修正
`LoginState` -> `ILoginState`
`Category` -> `ICategory`