### PR TITLE
APIへのリクエスト処理を作成する

### DIFF
--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -59,7 +59,7 @@ export default class Category extends Vue {
   }
 
   isActive(id: ICategory["id"]) {
-    return id === "1";
+    return id === 1;
   }
 
   doneEdit() {

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -59,7 +59,6 @@ export default class Category extends Vue {
   }
 
   isActive(id: ICategory["categoryId"]) {
-    console.log(id);
     return id === 1;
   }
 

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -2,9 +2,9 @@
   <li>
     <div v-if="!editing">
       <a
-        :data-category="category.id"
+        :data-category="category.categoryId"
         @click="clickHandle"
-        :class="`${isActive(category.id) && 'is-active'}`"
+        :class="`${isActive(category.categoryId) && 'is-active'}`"
       >
         {{ category.name }}
         <p class="edit" @click="editing = true;">編集</p>
@@ -58,7 +58,8 @@ export default class Category extends Vue {
     console.log(`${event.target.dataset.category} clicked!!`);
   }
 
-  isActive(id: ICategory["id"]) {
+  isActive(id: ICategory["categoryId"]) {
+    console.log(id);
     return id === 1;
   }
 

--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse, AxiosError } from "axios";
 import QiitaStockerApiFactory from "@/factory/api/QiitaStockerApiFactory";
 import QiitaApiFactory from "@/factory/api/QiitaApiFactory";
+import { ICategory } from "@/types/login";
 
 export const STORAGE_KEY_AUTH_STATE = "authorizationState";
 export const STORAGE_KEY_ACCOUNT_ACTION = "accountAction";
@@ -23,6 +24,9 @@ export interface IQiitaStockerApi {
   issueLoginSession(
     request: IIssueLoginSessionRequest
   ): Promise<IIssueLoginSessionResponse>;
+  fetchCategories(
+    request: IFetchCategoriesRequest
+  ): Promise<IFetchCategoriesResponse[]>;
   saveCategory(request: ISaveCategoryRequest): Promise<ISaveCategoryResponse>;
 }
 
@@ -92,16 +96,20 @@ export interface ICancelAccountRequest {
   sessionId: string;
 }
 
+export interface IFetchCategoriesRequest {
+  apiUrlBase: string;
+  sessionId: string;
+}
+
+export interface IFetchCategoriesResponse extends ICategory {}
+
 export interface ISaveCategoryRequest {
   apiUrlBase: string;
   name: string;
   sessionId: string;
 }
 
-export interface ISaveCategoryResponse {
-  categoryId: string;
-  name: string;
-}
+export interface ISaveCategoryResponse extends ICategory {}
 
 interface IQiitaStockerErrorData {
   code: number;
@@ -164,6 +172,12 @@ export const saveCategory = async (
   request: ISaveCategoryRequest
 ): Promise<ISaveCategoryResponse> => {
   return await qiitaStockerApi.saveCategory(request);
+};
+
+export const fetchCategories = async (
+  request: IFetchCategoriesRequest
+): Promise<IFetchCategoriesResponse[]> => {
+  return await qiitaStockerApi.fetchCategories(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -8,7 +8,9 @@ import {
   IQiitaStockerError,
   ICancelAccountRequest,
   ISaveCategoryRequest,
-  ISaveCategoryResponse
+  ISaveCategoryResponse,
+  IFetchCategoriesRequest,
+  IFetchCategoriesResponse
 } from "@/domain/Qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -67,6 +69,22 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
           }
         }
       )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+  async fetchCategories(
+    request: IFetchCategoriesRequest
+  ): Promise<IFetchCategoriesResponse[]> {
+    return await axios
+      .get<IFetchCategoriesRequest>(`${request.apiUrlBase}/api/categories`, {
+        headers: {
+          Authorization: `Bearer ${request.sessionId}`
+        }
+      })
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve(axiosResponse.data);
       })

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -28,6 +28,9 @@ import {
   saveCategory,
   ISaveCategoryRequest,
   ISaveCategoryResponse,
+  fetchCategories,
+  IFetchCategoriesRequest,
+  IFetchCategoriesResponse,
   unauthorizedMessage
 } from "@/domain/Qiita";
 import uuid from "uuid";
@@ -277,7 +280,7 @@ const actions: ActionTree<ILoginState, RootState> = {
       );
 
       const savedCategory: ICategory = {
-        id: saveCategoryResponse.categoryId,
+        id: saveCategoryResponse.id,
         name: saveCategoryResponse.name
       };
 
@@ -292,23 +295,15 @@ const actions: ActionTree<ILoginState, RootState> = {
   },
   fetchCategory: async ({ commit }) => {
     try {
-      // TODO カテゴリ取得APIからカテゴリ一覧を取得する
+      const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+      const fetchCategoriesRequest: IFetchCategoriesRequest = {
+        apiUrlBase: apiUrlBase(),
+        sessionId: sessionId
+      };
 
-      // 仮実装として仮のカテゴリ一覧を用意
-      const categories: ICategory[] = [
-        {
-          id: "1",
-          name: "設計"
-        },
-        {
-          id: "2",
-          name: "テスト"
-        },
-        {
-          id: "3",
-          name: "ドメイン駆動設計"
-        }
-      ];
+      const categories: IFetchCategoriesResponse[] = await fetchCategories(
+        fetchCategoriesRequest
+      );
 
       commit("saveCategory", categories);
     } catch (error) {

--- a/src/store/modules/Qiita.ts
+++ b/src/store/modules/Qiita.ts
@@ -280,7 +280,7 @@ const actions: ActionTree<ILoginState, RootState> = {
       );
 
       const savedCategory: ICategory = {
-        id: saveCategoryResponse.id,
+        categoryId: saveCategoryResponse.categoryId,
         name: saveCategoryResponse.name
       };
 

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -7,6 +7,6 @@ export interface ILoginState {
 }
 
 export interface ICategory {
-  id: string;
+  id: number;
   name: string;
 }

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -7,6 +7,6 @@ export interface ILoginState {
 }
 
 export interface ICategory {
-  id: number;
+  categoryId: number;
   name: string;
 }

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -111,15 +111,15 @@ describe("QiitaModule", () => {
     it("should be able to save categories", () => {
       const categories: ICategory[] = [
         {
-          id: 1,
+          categoryId: 1,
           name: "テストカテゴリー1"
         },
         {
-          id: 2,
+          categoryId: 2,
           name: "テストカテゴリー2"
         },
         {
-          id: 3,
+          categoryId: 3,
           name: "テストカテゴリー3"
         }
       ];
@@ -132,7 +132,7 @@ describe("QiitaModule", () => {
 
     it("should be able to add categories", () => {
       const category: ICategory = {
-        id: 1,
+        categoryId: 1,
         name: "テストカテゴリー"
       };
       const wrapper = (mutations: any) =>
@@ -257,7 +257,7 @@ describe("QiitaModule", () => {
 
       const mockPostResponse: { data: ISaveCategoryResponse } = {
         data: {
-          id: categoryId,
+          categoryId: categoryId,
           name: categoryName
         }
       };
@@ -272,7 +272,7 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       const savedCategory: ICategory = {
-        id: categoryId,
+        categoryId: categoryId,
         name: categoryName
       };
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -111,15 +111,15 @@ describe("QiitaModule", () => {
     it("should be able to save categories", () => {
       const categories: ICategory[] = [
         {
-          id: "1",
+          id: 1,
           name: "テストカテゴリー1"
         },
         {
-          id: "2",
+          id: 2,
           name: "テストカテゴリー2"
         },
         {
-          id: "3",
+          id: 3,
           name: "テストカテゴリー3"
         }
       ];
@@ -132,7 +132,7 @@ describe("QiitaModule", () => {
 
     it("should be able to add categories", () => {
       const category: ICategory = {
-        id: "1",
+        id: 1,
         name: "テストカテゴリー"
       };
       const wrapper = (mutations: any) =>
@@ -252,12 +252,12 @@ describe("QiitaModule", () => {
     });
 
     it("should be able to save category", async () => {
-      const categoryId = "1";
+      const categoryId = 1;
       const categoryName: string = "テストカテゴリー";
 
       const mockPostResponse: { data: ISaveCategoryResponse } = {
         data: {
-          categoryId: categoryId,
+          id: categoryId,
           name: categoryName
         }
       };

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -5,7 +5,8 @@ import {
   IIssueAccessTokensResponse,
   IFetchAuthenticatedUserResponse,
   IAuthorizationResponse,
-  ISaveCategoryResponse
+  ISaveCategoryResponse,
+  IFetchCategoriesResponse
 } from "@/domain/Qiita";
 
 jest.mock("@/domain/Qiita");
@@ -277,6 +278,37 @@ describe("QiitaModule", () => {
       };
 
       expect(commit.mock.calls).toEqual([["addCategory", savedCategory]]);
+    });
+
+    it("should be able to fetch categories", async () => {
+      const categories: IFetchCategoriesResponse[] = [
+        {
+          categoryId: 1,
+          name: "テストカテゴリー1"
+        },
+        {
+          categoryId: 2,
+          name: "テストカテゴリー2"
+        },
+        {
+          categoryId: 3,
+          name: "テストカテゴリー3"
+        }
+      ];
+
+      const mockPostResponse: { data: IFetchCategoriesResponse[] } = {
+        data: categories
+      };
+
+      const mockAxios: any = axios;
+      mockAxios.get.mockResolvedValue(mockPostResponse);
+
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) => actions.fetchCategory({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["saveCategory", categories]]);
     });
   });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/93

# Doneの定義
- カテゴリ取得APIとフロントエンドが通信できていること
- 取得したカテゴリ一覧が表示されていること

# 変更点概要

## 仕様的変更点概要
カテゴリ取得APIへのリクエスト処理を作成

## 技術的変更点概要
- `ICategory`で定義しているカテゴリのInterfaceを修正
- axiosを使用したカテゴリ取得APIへのリクエスト処理を追加
- actionのテストケースを追加

# レビュアーに重点的にチェックして欲しい点
Interfaceの継承を利用しているが、このケースで継承を用いて問題ないか