### PR TITLE
退会画面のスタイリング

### DIFF
--- a/src/pages/cencel/Cancel.vue
+++ b/src/pages/cencel/Cancel.vue
@@ -1,19 +1,41 @@
 <template>
-  <div>
-    <h1>退会</h1>
-    <button @click="cancel">退会する</button>
-  </div>
+  <section class="hero is-fullheight">
+    <AppHeader />
+    <main>
+      <div class="container has-text-centered">
+        <h1 class="title">退会</h1>
+        <button class="button is-danger" @click="cancel">退会する</button>
+        <h2 class="is-size-6 cancel-guide">
+          アカウントの情報が全て削除されます。<br />削除した情報を復元することはできません。
+        </h2>
+      </div>
+    </main>
+    <AppFooter />
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Action, namespace } from "vuex-class";
+import AppHeader from "@/components/AppHeader.vue";
+import AppFooter from "@/components/AppFooter.vue";
 
 const QiitaAction = namespace("QiitaModule", Action);
 
-@Component
+@Component({
+  components: {
+    AppHeader,
+    AppFooter
+  }
+})
 export default class Cancel extends Vue {
   @QiitaAction
   cancel!: () => void;
 }
 </script>
+
+<style scoped>
+.cancel-guide {
+  padding-top: 1rem;
+}
+</style>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/106

# Doneの定義
- 退会画面にcssが当てられていること

# スクリーンショット
<img width="1394" alt="2018-11-15 23 31 32" src="https://user-images.githubusercontent.com/32682645/48559281-a624d800-e92e-11e8-9fb3-c8c3ccd75516.png">

# 変更点概要

## 技術的変更点概要
`Cancel`コンポーネントのスタイルを修正

# 補足情報
退会APIに、カテゴリ削除の処理を追加していないので、退会ボタンを押下するとエラーが表示される。
これについては、https://github.com/nekochans/qiita-stocker-backend/issues/63 で対応する。

ヘッダーの設定をクリックすると、いきなり退会画面が表示されるようになっているが、退会画面への動線も検討する必要がある。