### PR TITLE
退会完了画面のスタイリング 

### DIFF
--- a/src/pages/cencel/complete/CancelComplete.vue
+++ b/src/pages/cencel/complete/CancelComplete.vue
@@ -1,17 +1,30 @@
 <template>
-  <div>
-    <h1>退会完了</h1>
-    <p>
-      退会が完了しました。<br />
-      ご利用いただき、ありがとうございました。<br />
-      またのご利用をお待ちしております。
-    </p>
-  </div>
+  <section class="hero is-fullheight">
+    <AppHeader />
+    <main>
+      <div class="container has-text-centered">
+        <h1 class="title">退会完了</h1>
+        <h2 class="is-size-6">
+          退会が完了しました。<br />
+          ご利用いただき、ありがとうございました。<br />
+          またのご利用をお待ちしております。
+        </h2>
+      </div>
+    </main>
+    <AppFooter />
+  </section>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import AppHeader from "@/components/AppHeader.vue";
+import AppFooter from "@/components/AppFooter.vue";
 
-@Component
+@Component({
+  components: {
+    AppHeader,
+    AppFooter
+  }
+})
 export default class CancelComplete extends Vue {}
 </script>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/105

# Doneの定義
- 退会完了画面にcssが当てられていること

# スクリーンショット
<img width="1337" alt="2018-11-15 23 59 32" src="https://user-images.githubusercontent.com/32682645/48561076-8d1e2600-e932-11e8-90b3-7430e0d913f7.png">

# 変更点概要
## 技術的変更点概要
`CancelComplete`コンポーネントのスタイルを修正

# 補足情報
退会処理でエラーとなるので、下記URLを直接確認。
http://localhost:8080/cancel/complete