### PR TITLE
カテゴリ追加時のバリデーション処理を追加

### DIFF
--- a/src/components/CreateCategory.vue
+++ b/src/components/CreateCategory.vue
@@ -6,12 +6,15 @@
     <div v-show="editing">
       <div class="field">
         <input
-          class="input"
+          :class="`input ${isValidationError && 'is-danger'}`"
           type="text"
           v-focus="editing"
           v-model="category"
           @input="setCategory"
         />
+        <p v-if="isValidationError" class="help is-danger">
+          カテゴリを入力してください。
+        </p>
       </div>
       <div class="field">
         <p class="control">
@@ -45,14 +48,21 @@ import { Component, Vue } from "vue-property-decorator";
 export default class CreateCategory extends Vue {
   editing: boolean = false;
   category: string = "";
+  isValidationError: boolean = false;
 
   doneEdit() {
+    this.isValidationError = false;
     this.category = "";
     this.editing = false;
   }
 
   onClickSaveCategory() {
-    // TODO バリデーションを追加する
+    this.category = this.category.trim();
+    if (this.category === "") {
+      this.isValidationError = true;
+      return;
+    }
+
     this.$emit("clickSaveCategory", this.category);
     this.doneEdit();
   }

--- a/tests/unit/CreateCategory.spec.ts
+++ b/tests/unit/CreateCategory.spec.ts
@@ -18,6 +18,19 @@ describe("CreateCategory.vue", () => {
         inputtedCategory
       );
     });
+
+    it("should not emit clickSaveCategory on onClickSaveCategory()", () => {
+      const wrapper = shallowMount(CreateCategory);
+      const inputtedCategory = " ";
+
+      // @ts-ignore
+      wrapper.vm.category = inputtedCategory;
+
+      // @ts-ignore
+      wrapper.vm.onClickSaveCategory();
+
+      expect(wrapper.emitted("clickSaveCategory")).toBeFalsy();
+    });
   });
 
   describe("template", () => {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/103

# Doneの定義
- バリデーションエラーの場合、エラーメッセージが表示されること

# スクリーンショット
<img width="312" alt="2018-11-16 16 21 48" src="https://user-images.githubusercontent.com/32682645/48604021-c9e22f80-e9bb-11e8-8e65-0d064a26c50a.png">


# 変更点概要

## 仕様的変更点概要
カテゴリが未入力の場合、下記のエラーメッセージを表示する
エラーメッセージ：`カテゴリを入力してください。`

## 技術的変更点概要
`CreateCategory`コンポーネントにエラーメッセージの表示処理を追加。
カテゴリが未入力だった場合のテストケースを追加。