### PR TITLE
actionを作成しコンポーネントから呼び出す処理を追加

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -39,14 +39,14 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Getter, namespace } from "vuex-class";
-import { ILoginState } from "@/types/qiita";
+import { IQiitaState } from "@/types/qiita";
 
 const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
 export default class AppHeader extends Vue {
   @QiitaGetter
-  isLoggedIn!: ILoginState["isLoggedIn"];
+  isLoggedIn!: IQiitaState["isLoggedIn"];
 
   isMenuActive: boolean = false;
 

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -13,19 +13,25 @@
     <div v-show="editing">
       <div class="field">
         <input
-          class="input edit-field"
+          :class="`input edit-field ${isValidationError && 'is-danger'}`"
           type="text"
           v-focus="editing"
-          :value="category.name"
+          v-model="editCategoryName"
         />
         <a class="has-text-grey is-size-7 destroy">削除</a>
+        <p v-if="isValidationError" class="help is-danger">
+          カテゴリを入力してください。
+        </p>
       </div>
       <div class="field">
         <p class="control">
-          <button class="button is-small is-danger" @click="doneEdit">
-            カテゴリを追加
+          <button
+            class="button is-small is-danger"
+            @click="onClickUpdateCategory"
+          >
+            保存
           </button>
-          <a class="has-text-grey is-size-7 cancel" @click="cancelEdit"
+          <a class="has-text-grey is-size-7 cancel" @click="doneEdit"
             >キャンセル</a
           >
         </p>
@@ -37,6 +43,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 
 @Component({
   directives: {
@@ -52,6 +59,8 @@ export default class Category extends Vue {
   category!: ICategory;
 
   editing: boolean = false;
+  editCategoryName = this.category.name;
+  isValidationError: boolean = false;
 
   clickHandle(event: any) {
     // TODO 選択されたカテゴリの記事を表示する
@@ -63,11 +72,25 @@ export default class Category extends Vue {
   }
 
   doneEdit() {
+    this.isValidationError = false;
+    this.editCategoryName = this.category.name;
     this.editing = false;
   }
 
-  cancelEdit() {
-    this.editing = false;
+  onClickUpdateCategory() {
+    this.editCategoryName = this.editCategoryName.trim();
+    if (this.editCategoryName === "") {
+      this.isValidationError = true;
+      return;
+    }
+
+    const updateCategoryPayload: IUpdateCategoryPayload = {
+      stateCategory: this.category,
+      categoryName: this.editCategoryName
+    };
+
+    this.$emit("clickUpdateCategory", updateCategoryPayload);
+    this.doneEdit();
   }
 }
 </script>

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -23,7 +23,7 @@ import Category from "@/components/Category.vue";
     Category
   }
 })
-export default class SideMenuList extends Vue {
+export default class CategoryList extends Vue {
   @Prop()
   categories!: ICategory[];
 

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,6 +1,10 @@
 <template>
   <aside class="submenu menu">
-    <SideMenuSearch /> <SideMenuList :categories="categories" />
+    <SideMenuSearch />
+    <SideMenuList
+      :categories="categories"
+      @clickUpdateCategory="onClickUpdateCategory"
+    />
     <CreateCategory @clickSaveCategory="onClickSaveCategory" />
   </aside>
 </template>
@@ -11,6 +15,7 @@ import SideMenuSearch from "@/components/SideMenuSearch.vue";
 import SideMenuList from "@/components/SideMenuList.vue";
 import CreateCategory from "@/components/CreateCategory.vue";
 import { ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 
 @Component({
   components: {
@@ -25,6 +30,10 @@ export default class SideMenu extends Vue {
 
   onClickSaveCategory(category: string) {
     this.$emit("clickSaveCategory", category);
+  }
+
+  onClickUpdateCategory(updateCategoryPayload: IUpdateCategoryPayload) {
+    this.$emit("clickUpdateCategory", updateCategoryPayload);
   }
 }
 </script>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="submenu menu">
     <SideMenuSearch />
-    <SideMenuList
+    <CategoryList
       :categories="categories"
       @clickUpdateCategory="onClickUpdateCategory"
     />
@@ -12,7 +12,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import SideMenuSearch from "@/components/SideMenuSearch.vue";
-import SideMenuList from "@/components/SideMenuList.vue";
+import CategoryList from "@/components/CategoryList.vue";
 import CreateCategory from "@/components/CreateCategory.vue";
 import { ICategory } from "@/domain/qiita";
 import { IUpdateCategoryPayload } from "@/store/modules/qiita";
@@ -20,7 +20,7 @@ import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 @Component({
   components: {
     SideMenuSearch,
-    SideMenuList,
+    CategoryList,
     CreateCategory
   }
 })

--- a/src/components/SideMenuList.vue
+++ b/src/components/SideMenuList.vue
@@ -6,6 +6,7 @@
         v-for="category in categories"
         :key="category.id"
         :category="category"
+        @clickUpdateCategory="onClickUpdateCategory"
       />
     </ul>
   </section>
@@ -14,6 +15,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 import Category from "@/components/Category.vue";
 
 @Component({
@@ -24,6 +26,10 @@ import Category from "@/components/Category.vue";
 export default class SideMenuList extends Vue {
   @Prop()
   categories!: ICategory[];
+
+  onClickUpdateCategory(updateCategoryPayload: IUpdateCategoryPayload) {
+    this.$emit("clickUpdateCategory", updateCategoryPayload);
+  }
 }
 </script>
 

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -7,6 +7,7 @@
           <SideMenu
             :categories="categories"
             @clickSaveCategory="onClickSaveCategory"
+            @clickUpdateCategory="onClickUpdateCategory"
           />
         </div>
         <div class="column is-9">
@@ -26,6 +27,7 @@ import SideMenu from "@/components/SideMenu.vue";
 import MediaList from "@/components/MediaList.vue";
 import Pagination from "@/components/Pagination.vue";
 import { IQiitaItem, ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
@@ -73,10 +75,17 @@ export default class Account extends Vue {
   saveCategory!: (category: string) => void;
 
   @QiitaAction
-  fetchCategory!: () => ICategory[];
+  fetchCategory!: () => void;
 
-  onClickSaveCategory(category: string) {
-    this.saveCategory(category);
+  @QiitaAction
+  updateCategory!: (updateCategoryPayload: IUpdateCategoryPayload) => void;
+
+  onClickSaveCategory(categoryName: string) {
+    this.saveCategory(categoryName);
+  }
+
+  onClickUpdateCategory(updateCategoryPayload: IUpdateCategoryPayload) {
+    this.updateCategory(updateCategoryPayload);
   }
 
   created() {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -64,6 +64,11 @@ interface IFetchUserPayload {
   accountAction: "signUp" | "login";
 }
 
+export interface IUpdateCategoryPayload {
+  stateCategory: ICategory;
+  categoryName: string;
+}
+
 const state: IQiitaState = {
   authorizationCode: "",
   accessToken: "",
@@ -105,6 +110,12 @@ const mutations: MutationTree<IQiitaState> = {
   },
   addCategory: (state, category: ICategory) => {
     state.categories.push(category);
+  },
+  updateCategory: (
+    state,
+    updateCategory: { stateCategory: ICategory; categoryName: string }
+  ) => {
+    updateCategory.stateCategory.name = updateCategory.categoryName;
   }
 };
 
@@ -307,6 +318,21 @@ const actions: ActionTree<IQiitaState, RootState> = {
       );
 
       commit("saveCategory", categories);
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
+  },
+  updateCategory: async (
+    { commit },
+    updateCategory: IUpdateCategoryPayload
+  ) => {
+    try {
+      // TODO カテゴリ変更APIへのリクエスト処理
+      commit("updateCategory", updateCategory);
     } catch (error) {
       router.push({
         name: "error",

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -1,4 +1,4 @@
-import { ICategory} from "@/domain/qiita";
+import { ICategory } from "@/domain/qiita";
 
 export interface IQiitaState {
   authorizationCode: string;

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -1,8 +1,9 @@
 import { shallowMount, mount, createLocalVue, config } from "@vue/test-utils";
 import Vuex from "vuex";
-import { QiitaModule } from "@/store/modules/qiita";
+import { IUpdateCategoryPayload, QiitaModule } from "@/store/modules/qiita";
 import Account from "@/pages/Account.vue";
 import SideMenu from "@/components/SideMenu.vue";
+import CategoryList from "@/components/CategoryList.vue";
 import { IQiitaState } from "@/types/qiita";
 import VueRouter from "vue-router";
 
@@ -31,6 +32,7 @@ describe("Account.vue", () => {
 
     actions = {
       saveCategory: jest.fn(),
+      updateCategory: jest.fn(),
       fetchCategory: jest.fn()
     };
 
@@ -57,6 +59,27 @@ describe("Account.vue", () => {
       expect(actions.saveCategory).toHaveBeenCalledWith(
         expect.anything(),
         inputtedCategory,
+        undefined
+      );
+    });
+
+    it('calls store action "updateCategory" on onClickUpdateCategory()', () => {
+      state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
+
+      const wrapper = shallowMount(Account, { store, localVue, router });
+      const editedCategory = "編集されたカテゴリ名";
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: state.categories[0],
+        categoryName: editedCategory
+      };
+
+      // @ts-ignore
+      wrapper.vm.onClickUpdateCategory(updateCategoryPayload);
+
+      expect(actions.updateCategory).toHaveBeenCalledWith(
+        expect.anything(),
+        updateCategoryPayload,
         undefined
       );
     });
@@ -89,5 +112,29 @@ describe("Account.vue", () => {
 
       expect(mock).toHaveBeenCalledWith(inputtedCategory);
     });
+  });
+
+  it("should call onClickUpdateCategory when button is clicked", () => {
+    state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
+
+    const mock = jest.fn();
+    const wrapper = mount(Account, { store, localVue, router });
+
+    wrapper.setMethods({
+      onClickUpdateCategory: mock
+    });
+
+    const categoryList = wrapper.find(CategoryList);
+    const editedCategory = "編集されたカテゴリ名";
+
+    const updateCategoryPayload: IUpdateCategoryPayload = {
+      stateCategory: state.categories[0],
+      categoryName: editedCategory
+    };
+
+    // @ts-ignore
+    categoryList.vm.onClickUpdateCategory(updateCategoryPayload);
+
+    expect(mock).toHaveBeenCalledWith(updateCategoryPayload);
   });
 });

--- a/tests/unit/Category.spec.ts
+++ b/tests/unit/Category.spec.ts
@@ -1,0 +1,66 @@
+import { shallowMount } from "@vue/test-utils";
+import Category from "@/components/Category.vue";
+import { ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
+
+describe("Category.vue", () => {
+  const propsData: { category: ICategory } = {
+    category: { categoryId: 1, name: "テストカテゴリ" }
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(Category, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickSaveCategory on onClickUpdateCategory()", () => {
+      const wrapper = shallowMount(Category, { propsData });
+      const editedCategory = "編集されたカテゴリ名";
+
+      // @ts-ignore
+      wrapper.vm.editCategoryName = editedCategory;
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: propsData.category,
+        categoryName: editedCategory
+      };
+
+      // @ts-ignore
+      wrapper.vm.onClickUpdateCategory();
+
+      expect(wrapper.emitted("clickUpdateCategory")).toBeTruthy();
+      expect(wrapper.emitted("clickUpdateCategory")[0][0]).toEqual(
+        updateCategoryPayload
+      );
+    });
+
+    it("should not emit clickSaveCategory on onClickUpdateCategory()", () => {
+      const wrapper = shallowMount(Category, { propsData });
+      const editedCategory = " ";
+
+      // @ts-ignore
+      wrapper.vm.editCategoryName = editedCategory;
+
+      // @ts-ignore
+      wrapper.vm.onClickUpdateCategory();
+
+      expect(wrapper.emitted("clickUpdateCategory")).toBeFalsy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call onClickUpdateCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Category, { propsData });
+
+      wrapper.setMethods({
+        onClickUpdateCategory: mock
+      });
+
+      wrapper.find("button").trigger("click");
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/CateogryList.spec.ts
+++ b/tests/unit/CateogryList.spec.ts
@@ -1,0 +1,61 @@
+import { shallowMount, mount, config } from "@vue/test-utils";
+import CategoryList from "@/components/CategoryList.vue";
+import Category from "@/components/Category.vue";
+import { ICategory } from "@/domain/qiita";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
+
+config.logModifiedComponents = false;
+
+describe("CategoryList.vue", () => {
+  const propsData: { categories: ICategory[] } = {
+    categories: [{ categoryId: 1, name: "テストカテゴリ" }]
+  };
+
+  describe("methods", () => {
+    it("should emit clickUpdateCategory on onClickUpdateCategory()", () => {
+      const wrapper = shallowMount(CategoryList, { propsData });
+      const editedCategory = "編集されたカテゴリ名";
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: propsData.categories[0],
+        categoryName: editedCategory
+      };
+
+      // @ts-ignore
+      wrapper.vm.onClickUpdateCategory(updateCategoryPayload);
+
+      expect(wrapper.emitted("clickUpdateCategory")).toBeTruthy();
+      expect(wrapper.emitted("clickUpdateCategory")[0][0]).toEqual(
+        updateCategoryPayload
+      );
+    });
+  });
+
+  // mountによる結合テスト
+  describe("template", () => {
+    it("should call clickUpdateCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(CategoryList, { propsData });
+
+      wrapper.setMethods({
+        onClickUpdateCategory: mock
+      });
+
+      const category = wrapper.find(Category);
+      const editedCategory = "編集されたカテゴリ名";
+
+      // @ts-ignore
+      category.vm.editCategoryName = editedCategory;
+
+      // @ts-ignore
+      category.vm.onClickUpdateCategory();
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: propsData.categories[0],
+        categoryName: editedCategory
+      };
+
+      expect(mock).toHaveBeenCalledWith(updateCategoryPayload);
+    });
+  });
+});

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -143,6 +143,24 @@ describe("QiitaModule", () => {
 
       expect(state.categories[0]).toEqual(category);
     });
+
+    it("should be able to update category", () => {
+      state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
+
+      const updateCategory: {
+        stateCategory: ICategory;
+        categoryName: string;
+      } = {
+        stateCategory: state.categories[0],
+        categoryName: "編集したカテゴリ名"
+      };
+
+      const wrapper = (mutations: any) =>
+        mutations.updateCategory(state, updateCategory);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.categories[0].name).toEqual(updateCategory.categoryName);
+    });
   });
 
   describe("actions", () => {
@@ -310,6 +328,24 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([["saveCategory", categories]]);
+    });
+
+    it("should be able to update category", async () => {
+      const updateCategory: {
+        stateCategory: ICategory;
+        categoryName: string;
+      } = {
+        stateCategory: { categoryId: 1, name: "テストカテゴリ" },
+        categoryName: "編集したカテゴリ名"
+      };
+
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) =>
+        actions.updateCategory({ commit }, updateCategory);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["updateCategory", updateCategory]]);
     });
   });
 });

--- a/tests/unit/SideMenu.spec.ts
+++ b/tests/unit/SideMenu.spec.ts
@@ -1,13 +1,20 @@
 import { shallowMount, mount, config } from "@vue/test-utils";
 import SideMenu from "@/components/SideMenu.vue";
 import CreateCategory from "@/components/CreateCategory.vue";
+import CategoryList from "@/components/CategoryList.vue";
+import { IUpdateCategoryPayload } from "@/store/modules/qiita";
+import { ICategory } from "@/domain/qiita";
 
 config.logModifiedComponents = false;
 
 describe("SideMenu.vue", () => {
+  const propsData: { categories: ICategory[] } = {
+    categories: [{ categoryId: 1, name: "テストカテゴリ" }]
+  };
+
   describe("methods", () => {
     it("should emit clickSaveCategory on onClickSaveCategory()", () => {
-      const wrapper = shallowMount(SideMenu);
+      const wrapper = shallowMount(SideMenu, { propsData });
       const inputtedCategory = "inputtedCategory";
 
       // @ts-ignore
@@ -18,13 +25,31 @@ describe("SideMenu.vue", () => {
         inputtedCategory
       );
     });
+
+    it("should emit clickUpdateCategory on onClickUpdateCategory()", () => {
+      const wrapper = shallowMount(SideMenu, { propsData });
+      const editedCategory = "編集されたカテゴリ名";
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: propsData.categories[0],
+        categoryName: editedCategory
+      };
+
+      // @ts-ignore
+      wrapper.vm.onClickUpdateCategory(updateCategoryPayload);
+
+      expect(wrapper.emitted("clickUpdateCategory")).toBeTruthy();
+      expect(wrapper.emitted("clickUpdateCategory")[0][0]).toEqual(
+        updateCategoryPayload
+      );
+    });
   });
 
   // mountによる結合テスト
   describe("template", () => {
     it("should call onClickSaveCategory when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = mount(SideMenu);
+      const wrapper = mount(SideMenu, { propsData });
 
       wrapper.setMethods({
         onClickSaveCategory: mock
@@ -41,5 +66,27 @@ describe("SideMenu.vue", () => {
 
       expect(mock).toHaveBeenCalledWith(inputtedCategory);
     });
+  });
+
+  it("should call onClickUpdateCategory when button is clicked", () => {
+    const mock = jest.fn();
+    const wrapper = mount(SideMenu, { propsData });
+
+    wrapper.setMethods({
+      onClickUpdateCategory: mock
+    });
+
+    const categoryList = wrapper.find(CategoryList);
+    const editedCategory = "編集されたカテゴリ名";
+
+    const updateCategoryPayload: IUpdateCategoryPayload = {
+      stateCategory: propsData.categories[0],
+      categoryName: editedCategory
+    };
+
+    // @ts-ignore
+    categoryList.vm.onClickUpdateCategory(updateCategoryPayload);
+
+    expect(mock).toHaveBeenCalledWith(updateCategoryPayload);
   });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/94

# Doneの定義
- actionが作成され、コンポーネントから呼び出されていること

# スクリーンショット
<img width="296" alt="2018-11-18 18 01 51" src="https://user-images.githubusercontent.com/32682645/48670494-12385380-eb5c-11e8-9ff5-02cb1dd5cc56.png">

# 変更点概要

## 仕様的変更点概要
- カテゴリ編集機能を追加
カテゴリ編集APIへのリクエスト処理は未実装のため、リロードすると編集内容が消える状態となっている。
- カテゴリが未入力の場合、エラーメッセージを表示する処理を追加
エラーメッセージ：`カテゴリを入力してください。`

## 技術的変更点概要
- カテゴリを更新するactionを仮実装し、`Category`コンポーネントから呼び出す処理を追加。
- コンポーネント名を　`SideMenuList.vue` -> `CategoryList.vue`に修正
- コンポーネントのテストケースを追加
- Vuexのmutationとactionのテストケースを追加

# 補足
actionに実装予定のカテゴリ編集APIへのリクエスト処理とそのテストケースは、次のPRで対応する。