### PR TITLE
カテゴリ編集APIへのリクエスト処理を作成

### DIFF
--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -27,6 +27,9 @@ export interface IQiitaStockerApi {
     request: IFetchCategoriesRequest
   ): Promise<IFetchCategoriesResponse[]>;
   saveCategory(request: ISaveCategoryRequest): Promise<ISaveCategoryResponse>;
+  updateCategory(
+    request: IUpdateCategoryRequest
+  ): Promise<IUpdateCategoryResponse>;
 }
 
 export interface IQiitaApi {
@@ -110,6 +113,15 @@ export interface ISaveCategoryRequest {
 
 export interface ISaveCategoryResponse extends ICategory {}
 
+export interface IUpdateCategoryRequest {
+  apiUrlBase: string;
+  sessionId: string;
+  categoryId: number;
+  name: string;
+}
+
+export interface IUpdateCategoryResponse extends ICategory {}
+
 interface IQiitaStockerErrorData {
   code: number;
   message: string;
@@ -182,6 +194,12 @@ export const fetchCategories = async (
   request: IFetchCategoriesRequest
 ): Promise<IFetchCategoriesResponse[]> => {
   return await qiitaStockerApi.fetchCategories(request);
+};
+
+export const updateCategory = async (
+  request: IUpdateCategoryRequest
+): Promise<IUpdateCategoryResponse> => {
+  return await qiitaStockerApi.updateCategory(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -10,7 +10,9 @@ import {
   ISaveCategoryRequest,
   ISaveCategoryResponse,
   IFetchCategoriesRequest,
-  IFetchCategoriesResponse
+  IFetchCategoriesResponse,
+  IUpdateCategoryRequest,
+  IUpdateCategoryResponse
 } from "@/domain/qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -97,8 +99,30 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
     request: ISaveCategoryRequest
   ): Promise<ISaveCategoryResponse> {
     return await axios
-      .post<IIssueLoginSessionResponse>(
+      .post<ISaveCategoryResponse>(
         `${request.apiUrlBase}/api/categories`,
+        { name: request.name },
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`,
+            "Content-Type": "application/json"
+          }
+        }
+      )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async updateCategory(
+    request: IUpdateCategoryRequest
+  ): Promise<IUpdateCategoryResponse> {
+    return await axios
+      .patch<IUpdateCategoryResponse>(
+        `${request.apiUrlBase}/api/categories/${request.categoryId}`,
         { name: request.name },
         {
           headers: {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -32,7 +32,10 @@ import {
   IFetchCategoriesRequest,
   IFetchCategoriesResponse,
   unauthorizedMessage,
-  ICategory
+  ICategory,
+  updateCategory,
+  IUpdateCategoryRequest,
+  IUpdateCategoryResponse
 } from "@/domain/qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -328,11 +331,25 @@ const actions: ActionTree<IQiitaState, RootState> = {
   },
   updateCategory: async (
     { commit },
-    updateCategory: IUpdateCategoryPayload
+    updateCategoryItem: IUpdateCategoryPayload
   ) => {
     try {
-      // TODO カテゴリ変更APIへのリクエスト処理
-      commit("updateCategory", updateCategory);
+      const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+      const updateCategoryRequest: IUpdateCategoryRequest = {
+        apiUrlBase: apiUrlBase(),
+        sessionId: sessionId,
+        categoryId: updateCategoryItem.stateCategory.categoryId,
+        name: updateCategoryItem.categoryName
+      };
+
+      const updateCategoryResponse: IUpdateCategoryResponse = await updateCategory(
+        updateCategoryRequest
+      );
+
+      commit("updateCategory", {
+        stateCategory: updateCategoryItem.stateCategory,
+        categoryName: updateCategoryResponse.name
+      });
     } catch (error) {
       router.push({
         name: "error",

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -7,7 +7,8 @@ import {
   IFetchAuthenticatedUserResponse,
   IAuthorizationResponse,
   ISaveCategoryResponse,
-  IFetchCategoriesResponse
+  IFetchCategoriesResponse,
+  IUpdateCategoryResponse
 } from "@/domain/qiita";
 
 jest.mock("@/domain/Qiita");
@@ -331,7 +332,7 @@ describe("QiitaModule", () => {
     });
 
     it("should be able to update category", async () => {
-      const updateCategory: {
+      const updateCategoryItem: {
         stateCategory: ICategory;
         categoryName: string;
       } = {
@@ -339,13 +340,25 @@ describe("QiitaModule", () => {
         categoryName: "編集したカテゴリ名"
       };
 
+      const mockPostResponse: { data: IUpdateCategoryResponse } = {
+        data: {
+          categoryId: updateCategoryItem.stateCategory.categoryId,
+          name: updateCategoryItem.categoryName
+        }
+      };
+
+      const mockAxios: any = axios;
+      mockAxios.patch.mockResolvedValue(mockPostResponse);
+
       const commit = jest.fn();
 
       const wrapper = (actions: any) =>
-        actions.updateCategory({ commit }, updateCategory);
+        actions.updateCategory({ commit }, updateCategoryItem);
       await wrapper(QiitaModule.actions);
 
-      expect(commit.mock.calls).toEqual([["updateCategory", updateCategory]]);
+      expect(commit.mock.calls).toEqual([
+        ["updateCategory", updateCategoryItem]
+      ]);
     });
   });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/94

# Doneの定義
- カテゴリ変更APIとフロントエンドが通信できていること

# 変更点概要

## 技術的変更点概要
カテゴリ編集APIへのリクエスト処理を作成
上記のテストケースも作成