### PR TITLE
リクエストにQiitaのアカウントIDを追加する

### DIFF
--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -69,11 +69,13 @@ export interface IFetchAuthenticatedUserRequest {
 }
 
 export interface IFetchAuthenticatedUserResponse {
+  id: string;
   permanent_id: string;
 }
 
 export interface ICreateAccountRequest {
   apiUrlBase: string;
+  qiitaAccountId: string;
   permanentId: string;
   accessToken: string;
 }
@@ -85,6 +87,7 @@ export interface ICreateAccountResponse {
 
 export interface IIssueLoginSessionRequest {
   apiUrlBase: string;
+  qiitaAccountId: string;
   permanentId: string;
   accessToken: string;
 }

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -23,6 +23,7 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
       .post<ICreateAccountResponse>(
         `${request.apiUrlBase}/api/accounts`,
         {
+          qiitaAccountId: request.qiitaAccountId,
           permanentId: request.permanentId,
           accessToken: request.accessToken
         },
@@ -62,6 +63,7 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
       .post<IIssueLoginSessionResponse>(
         `${request.apiUrlBase}/api/login-sessions`,
         {
+          qiitaAccountId: request.qiitaAccountId,
           permanentId: request.permanentId,
           accessToken: request.accessToken
         },

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -74,6 +74,7 @@ export interface IUpdateCategoryPayload {
 
 const state: IQiitaState = {
   authorizationCode: "",
+  qiitaAccountId: "",
   accessToken: "",
   permanentId: "",
   isLoggedIn: true,
@@ -104,6 +105,9 @@ const mutations: MutationTree<IQiitaState> = {
   },
   saveAccessToken: (state, accessToken: string) => {
     state.accessToken = accessToken;
+  },
+  saveQiitaAccountId: (state, qiitaAccountId: string) => {
+    state.qiitaAccountId = qiitaAccountId;
   },
   savePermanentId: (state, permanentId: string) => {
     state.permanentId = permanentId;
@@ -174,6 +178,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       );
 
       commit("savePermanentId", authenticatedUser.permanent_id);
+      commit("saveQiitaAccountId", authenticatedUser.id);
 
       switch (accountAction) {
         case "signUp":
@@ -204,6 +209,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
     try {
       const createAccountRequest: ICreateAccountRequest = {
         apiUrlBase: apiUrlBase(),
+        qiitaAccountId: state.qiitaAccountId,
         permanentId: state.permanentId,
         accessToken: state.accessToken
       };
@@ -234,6 +240,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
     try {
       const issueLoginSessionRequest: IIssueLoginSessionRequest = {
         apiUrlBase: apiUrlBase(),
+        qiitaAccountId: state.qiitaAccountId,
         permanentId: state.permanentId,
         accessToken: state.accessToken
       };

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -3,6 +3,7 @@ import { ICategory } from "@/domain/qiita";
 export interface IQiitaState {
   authorizationCode: string;
   accessToken: string;
+  qiitaAccountId: string;
   permanentId: string;
   isLoggedIn: boolean;
   categories: ICategory[];

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -25,6 +25,7 @@ describe("Account.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
+      qiitaAccountId: "",
       permanentId: "",
       isLoggedIn: true,
       categories: []

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -22,6 +22,7 @@ describe("Cancel.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
+      qiitaAccountId: "",
       permanentId: "",
       isLoggedIn: true,
       categories: []

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -22,6 +22,7 @@ describe("Login.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
+      qiitaAccountId: "",
       permanentId: "",
       isLoggedIn: false,
       categories: []

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -22,6 +22,7 @@ describe("QiitaModule", () => {
       state = {
         authorizationCode: "34d97d024861f098d2e45fb4d9ed7757f97f5b0f",
         accessToken: "72d79c218c16c65b8076c7de8ef6ec55504ca6a0",
+        qiitaAccountId: "test-user",
         permanentId: "1",
         isLoggedIn: false,
         categories: []
@@ -72,6 +73,7 @@ describe("QiitaModule", () => {
       state = {
         authorizationCode: "",
         accessToken: "",
+        qiitaAccountId: "",
         permanentId: "",
         isLoggedIn: false,
         categories: []
@@ -102,6 +104,14 @@ describe("QiitaModule", () => {
       expect(state.accessToken).toEqual(
         "72d79c218c16c65b8076c7de8ef6ec55504ca6a0"
       );
+    });
+
+    it("should be able to save qiitaAccountId", () => {
+      const wrapper = (mutations: any) =>
+        mutations.saveQiitaAccountId(state, "test-user");
+      wrapper(QiitaModule.mutations);
+
+      expect(state.qiitaAccountId).toEqual("test-user");
     });
 
     it("should be able to save permanentId", () => {
@@ -176,6 +186,7 @@ describe("QiitaModule", () => {
 
       const mockGetResponse: { data: IFetchAuthenticatedUserResponse } = {
         data: {
+          id: "test-user",
           permanent_id: "1"
         }
       };
@@ -203,7 +214,8 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([
         ["saveAuthorizationCode", "34d97d024861f098d2e45fb4d9ed7757f97f5b0f"],
         ["saveAccessToken", "72d79c218c16c65b8076c7de8ef6ec55504ca6a0"],
-        ["savePermanentId", "1"]
+        ["savePermanentId", "1"],
+        ["saveQiitaAccountId", "test-user"]
       ]);
 
       expect(dispatch.mock.calls).toEqual([["createAccount"]]);
@@ -220,6 +232,7 @@ describe("QiitaModule", () => {
 
       const mockGetResponse: { data: IFetchAuthenticatedUserResponse } = {
         data: {
+          id: "test-user",
           permanent_id: "1"
         }
       };
@@ -247,7 +260,8 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([
         ["saveAuthorizationCode", "34d97d024861f098d2e45fb4d9ed7757f97f5b0f"],
         ["saveAccessToken", "72d79c218c16c65b8076c7de8ef6ec55504ca6a0"],
-        ["savePermanentId", "1"]
+        ["savePermanentId", "1"],
+        ["saveQiitaAccountId", "test-user"]
       ]);
 
       expect(dispatch.mock.calls).toEqual([["issueLoginSession"]]);

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -22,6 +22,7 @@ describe("SignUp.vue", () => {
     state = {
       authorizationCode: "",
       accessToken: "",
+      qiitaAccountId: "",
       permanentId: "",
       isLoggedIn: false,
       categories: []


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/91

# Doneの定義
- アカウント作成APIへのリクエストにQiitaのユーザIDが追加されていること

# 変更点概要

## 仕様的変更点概要
以下のAPIへのリクエストにQiitaのアカウントIDを追加。
- アカウント作成API
- ログインAPI

QiitaのアカウントIDはユーザが変更できるため、ログイン時もサーバーに送信し同期する必要がある。

## 技術的変更点概要
各リクエスト処理に、QiitaのアカウントIDを送信する処理を追加。
Moduleのテストケースについても追加している。