### PR TITLE
ストック同期APIにリクエストを送る処理を作成

### DIFF
--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -30,6 +30,7 @@ export interface IQiitaStockerApi {
   updateCategory(
     request: IUpdateCategoryRequest
   ): Promise<IUpdateCategoryResponse>;
+  synchronizeStock(request: ISynchronizeStockRequest): Promise<void>;
 }
 
 export interface IQiitaApi {
@@ -130,6 +131,11 @@ interface IQiitaStockerErrorData {
   message: string;
 }
 
+export interface ISynchronizeStockRequest {
+  apiUrlBase: string;
+  sessionId: string;
+}
+
 export interface IQiitaStockerError extends AxiosError {
   response: AxiosResponse<IQiitaStockerErrorData>;
 }
@@ -203,6 +209,12 @@ export const updateCategory = async (
   request: IUpdateCategoryRequest
 ): Promise<IUpdateCategoryResponse> => {
   return await qiitaStockerApi.updateCategory(request);
+};
+
+export const synchronizeStock = async (
+  request: ISynchronizeStockRequest
+): Promise<void> => {
+  return await qiitaStockerApi.synchronizeStock(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -12,7 +12,8 @@ import {
   IFetchCategoriesRequest,
   IFetchCategoriesResponse,
   IUpdateCategoryRequest,
-  IUpdateCategoryResponse
+  IUpdateCategoryResponse,
+  ISynchronizeStockRequest
 } from "@/domain/qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -135,6 +136,25 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
       )
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async synchronizeStock(request: ISynchronizeStockRequest): Promise<void> {
+    return await axios
+      .put(
+        `${request.apiUrlBase}/api/stocks`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`
+          }
+        }
+      )
+      .then(() => {
+        return Promise.resolve();
       })
       .catch((axiosError: IQiitaStockerError) => {
         return Promise.reject(axiosError);

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -80,6 +80,9 @@ export default class Account extends Vue {
   @QiitaAction
   updateCategory!: (updateCategoryPayload: IUpdateCategoryPayload) => void;
 
+  @QiitaAction
+  synchronizeStock!: () => void;
+
   onClickSaveCategory(categoryName: string) {
     this.saveCategory(categoryName);
   }
@@ -90,12 +93,17 @@ export default class Account extends Vue {
 
   created() {
     this.initializeCategory();
+    this.initializeStock();
   }
 
   initializeCategory() {
     if (!this.categories.length) {
       this.fetchCategory();
     }
+  }
+
+  initializeStock() {
+    this.synchronizeStock();
   }
 }
 </script>

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -35,7 +35,9 @@ import {
   ICategory,
   updateCategory,
   IUpdateCategoryRequest,
-  IUpdateCategoryResponse
+  IUpdateCategoryResponse,
+  ISynchronizeStockRequest,
+  synchronizeStock
 } from "@/domain/qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -221,9 +223,6 @@ const actions: ActionTree<IQiitaState, RootState> = {
         createAccountRequest
       );
 
-      // TODO 発行されたアカウントIDをstateに保存するのか検討
-      console.log(createAccountResponse.accountId);
-
       commit("saveSessionId", createAccountResponse._embedded.sessionId);
 
       localStorage.save(
@@ -365,6 +364,23 @@ const actions: ActionTree<IQiitaState, RootState> = {
         stateCategory: updateCategoryItem.stateCategory,
         categoryName: updateCategoryResponse.name
       });
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
+  },
+  synchronizeStock: async ({ commit }) => {
+    try {
+      const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+      const synchronizeStockRequest: ISynchronizeStockRequest = {
+        apiUrlBase: apiUrlBase(),
+        sessionId: sessionId
+      };
+
+      await synchronizeStock(synchronizeStockRequest);
     } catch (error) {
       router.push({
         name: "error",

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -34,7 +34,8 @@ describe("Account.vue", () => {
     actions = {
       saveCategory: jest.fn(),
       updateCategory: jest.fn(),
-      fetchCategory: jest.fn()
+      fetchCategory: jest.fn(),
+      synchronizeStock: jest.fn(),
     };
 
     store = new Vuex.Store({
@@ -92,6 +93,15 @@ describe("Account.vue", () => {
       wrapper.vm.initializeCategory();
 
       expect(actions.fetchCategory).toHaveBeenCalled();
+    });
+
+    it('calls store action "synchronizeStock" on initializeStock()', () => {
+      const wrapper = shallowMount(Account, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.initializeStock();
+
+      expect(actions.synchronizeStock).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/129

# Doneの定義
- ストック同期APIとフロントエンドが通信できていること

# 変更点概要

## 仕様的変更点概要
ログイン後のページを表示する際に、ストック同期APIにリクエストするように修正。

## 技術的変更点概要
ModuleのActionに、ストック同期APIへのリクエスト処理を追加。
`Account`コンポーネントから呼び出している。