### PR TITLE
ストック取得APIにリクエストする処理を追加

### DIFF
--- a/src/components/Media.vue
+++ b/src/components/Media.vue
@@ -1,27 +1,30 @@
 <template>
   <article class="media">
     <figure class="media-left">
-      <a class="image is-48x48" :href="`https://qiita.com/${qiitaItem.userId}`">
-        <img :src="qiitaItem.profile_image_url" />
+      <a class="image is-48x48" :href="`https://qiita.com/${stock.user_id}`">
+        <img :src="stock.profile_image_url" />
       </a>
     </figure>
     <div class="media-content">
       <div class="content">
         <div class="item-info">
           <p>
-            <a :href="`https://qiita.com/${qiitaItem.userId}`">{{
-              qiitaItem.userId
+            <a :href="`https://qiita.com/${stock.user_id}`">{{
+              stock.user_id
             }}</a
-            >が{{ qiitaItem.created_at }}に投稿しました
+            >が{{ stock.article_created_at }}に投稿しました
           </p>
         </div>
         <div class="item-title">
-          <a :href="`https://qiita.com/kobayashi-m42/items/${qiitaItem.id}`">{{
-            qiitaItem.title
-          }}</a>
+          <a
+            :href="
+              `https://qiita.com/${stock.user_id}/items/${stock.article_id}`
+            "
+            >{{ stock.title }}</a
+          >
         </div>
         <div class="tags">
-          <span v-for="(tag, key) in qiitaItem.tags" :key="key" class="tag">
+          <span v-for="(tag, key) in stock.tags" :key="key" class="tag">
             {{ tag }}
           </span>
         </div>
@@ -32,12 +35,12 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-import { IQiitaItem } from "@/domain/qiita";
+import { IStock } from "@/domain/qiita";
 
 @Component
 export default class Media extends Vue {
   @Prop()
-  qiitaItem!: IQiitaItem[];
+  stock!: IStock[];
 }
 </script>
 

--- a/src/components/MediaList.vue
+++ b/src/components/MediaList.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <div v-if="qiitaItems.length">
+    <div v-if="stocks.length">
       <Media
-        v-if="qiitaItems.length"
-        v-for="qiitaItem in qiitaItems"
-        :qiitaItem="qiitaItem"
-        :key="qiitaItem.id"
+        v-if="stocks.length"
+        v-for="stock in stocks"
+        :stock="stock"
+        :key="stock.id"
       />
     </div>
     <div v-else><h1 class="subtitle">ストックされた記事はありません。</h1></div>
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import Media from "@/components/Media.vue";
-import { IQiitaItem } from "@/domain/qiita";
+import { IStock } from "@/domain/qiita";
 
 @Component({
   components: {
@@ -24,6 +24,6 @@ import { IQiitaItem } from "@/domain/qiita";
 })
 export default class MediaList extends Vue {
   @Prop()
-  qiitaItems!: IQiitaItem[];
+  stocks!: IStock[];
 }
 </script>

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -31,6 +31,7 @@ export interface IQiitaStockerApi {
     request: IUpdateCategoryRequest
   ): Promise<IUpdateCategoryResponse>;
   synchronizeStock(request: ISynchronizeStockRequest): Promise<void>;
+  fetchStocks(request: IFetchStockRequest): Promise<IFetchStockResponse>;
 }
 
 export interface IQiitaApi {
@@ -136,6 +137,24 @@ export interface ISynchronizeStockRequest {
   sessionId: string;
 }
 
+export interface IFetchStockRequest {
+  apiUrlBase: string;
+  sessionId: string;
+  page: string;
+  parPage: string;
+}
+
+export interface IPage {
+  page: string;
+  perPage: string;
+  relation: string;
+}
+
+export interface IFetchStockResponse {
+  paging: IPage[];
+  stocks: IStock[];
+}
+
 export interface IQiitaStockerError extends AxiosError {
   response: AxiosResponse<IQiitaStockerErrorData>;
 }
@@ -145,14 +164,14 @@ export interface ICategory {
   name: string;
 }
 
-// TODO 適切な値に修正する
-export interface IQiitaItem {
+export interface IStock {
   id: string;
+  article_id: string;
   title: string;
-  created_at: string;
-  tags: string[];
-  userId: string;
+  user_id: string;
   profile_image_url: string;
+  article_created_at: string;
+  tags: string[];
 }
 
 export const requestToAuthorizationServer = (
@@ -215,6 +234,12 @@ export const synchronizeStock = async (
   request: ISynchronizeStockRequest
 ): Promise<void> => {
   return await qiitaStockerApi.synchronizeStock(request);
+};
+
+export const fetchStocks = async (
+  request: IFetchStockRequest
+): Promise<IFetchStockResponse> => {
+  return await qiitaStockerApi.fetchStocks(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -11,7 +11,7 @@
           />
         </div>
         <div class="column is-9">
-          <MediaList :qiitaItems="qiitaItems" /> <Pagination />
+          <MediaList :stocks="stocks" /> <Pagination />
         </div>
       </div>
     </main>
@@ -26,7 +26,7 @@ import AppHeader from "@/components/AppHeader.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import MediaList from "@/components/MediaList.vue";
 import Pagination from "@/components/Pagination.vue";
-import { IQiitaItem, ICategory } from "@/domain/qiita";
+import { IStock, ICategory } from "@/domain/qiita";
 import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
@@ -41,35 +41,11 @@ const QiitaGetter = namespace("QiitaModule", Getter);
   }
 })
 export default class Account extends Vue {
-  qiitaItems: IQiitaItem[] = [
-    {
-      id: "c0a2609ae61a72dcc60f",
-      title: "CORSについて理解してLaravel5.6で対応する",
-      created_at: "2018/09/30",
-      tags: ["CORS", "laravel5.6", "laravel", "php"],
-      userId: "kobayashi-m42",
-      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
-    },
-    {
-      id: "1",
-      title: "CORSについて理解してLaravel5.6で対応する",
-      created_at: "2018/09/30",
-      tags: ["CORS", "laravel5.6", "laravel", "php"],
-      userId: "kobayashi-m42",
-      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
-    },
-    {
-      id: "2",
-      title: "CORSについて理解してLaravel5.6で対応する",
-      created_at: "2018/09/30",
-      tags: ["CORS", "laravel5.6", "laravel", "php"],
-      userId: "kobayashi-m42",
-      profile_image_url: "https://avatars3.githubusercontent.com/u/32682645?v=4"
-    }
-  ];
-
   @QiitaGetter
   categories!: ICategory[];
+
+  @QiitaGetter
+  stocks!: IStock[];
 
   @QiitaAction
   saveCategory!: (category: string) => void;
@@ -82,6 +58,9 @@ export default class Account extends Vue {
 
   @QiitaAction
   synchronizeStock!: () => void;
+
+  @QiitaAction
+  fetchStock!: () => void;
 
   onClickSaveCategory(categoryName: string) {
     this.saveCategory(categoryName);
@@ -102,8 +81,9 @@ export default class Account extends Vue {
     }
   }
 
-  initializeStock() {
-    this.synchronizeStock();
+  async initializeStock() {
+    await this.synchronizeStock();
+    await this.fetchStock();
   }
 }
 </script>

--- a/src/pages/oAuth/callback/OAuthCallback.vue
+++ b/src/pages/oAuth/callback/OAuthCallback.vue
@@ -20,12 +20,6 @@ export default class OAuthCallback extends Vue {
   @QiitaAction
   fetchUser!: (query: object) => void;
 
-  @QiitaAction
-  createAccount!: () => void;
-
-  @QiitaAction
-  issueLoginSession!: () => void;
-
   created() {
     const query: any = this.$route.query;
     const params: IAuthorizationResponse = {

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -1,4 +1,4 @@
-import { ICategory } from "@/domain/qiita";
+import { ICategory, IPage, IStock } from "@/domain/qiita";
 
 export interface IQiitaState {
   authorizationCode: string;
@@ -7,4 +7,6 @@ export interface IQiitaState {
   permanentId: string;
   sessionId: string;
   categories: ICategory[];
+  stocks: IStock[];
+  paging: IPage[];
 }

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -28,14 +28,16 @@ describe("Account.vue", () => {
       qiitaAccountId: "",
       permanentId: "",
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
-      categories: []
+      categories: [],
+      stocks: [],
+      paging: []
     };
 
     actions = {
       saveCategory: jest.fn(),
       updateCategory: jest.fn(),
       fetchCategory: jest.fn(),
-      synchronizeStock: jest.fn(),
+      synchronizeStock: jest.fn()
     };
 
     store = new Vuex.Store({

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -24,7 +24,9 @@ describe("AppHeader.vue", () => {
     qiitaAccountId: "",
     permanentId: "",
     sessionId: "",
-    categories: []
+    categories: [],
+    stocks: [],
+    paging: []
   };
 
   it("renders login", () => {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -25,7 +25,9 @@ describe("Cancel.vue", () => {
       qiitaAccountId: "",
       permanentId: "",
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
-      categories: []
+      categories: [],
+      stocks: [],
+      paging: []
     };
 
     actions = {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -25,7 +25,9 @@ describe("Login.vue", () => {
       qiitaAccountId: "",
       permanentId: "",
       sessionId: "",
-      categories: []
+      categories: [],
+      stocks: [],
+      paging: []
     };
 
     actions = {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -2,6 +2,7 @@ import { IQiitaState } from "@/types/qiita";
 import {
   ICategory,
   ICreateAccountResponse,
+  IFetchStockResponse,
   IIssueLoginSessionResponse
 } from "@/domain/qiita";
 import { QiitaModule } from "@/store/modules/qiita";
@@ -12,7 +13,9 @@ import {
   IAuthorizationResponse,
   ISaveCategoryResponse,
   IFetchCategoriesResponse,
-  IUpdateCategoryResponse
+  IUpdateCategoryResponse,
+  IStock,
+  IPage
 } from "@/domain/qiita";
 
 jest.mock("@/domain/Qiita");
@@ -21,6 +24,26 @@ jest.mock("axios");
 describe("QiitaModule", () => {
   describe("getters", () => {
     let state: IQiitaState;
+    const stocks: IStock[] = [
+      {
+        id: "1",
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"]
+      },
+      {
+        id: "2",
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title2",
+        user_id: "test-user12",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["Vue.js", "Vuex", "TypeScript"]
+      }
+    ];
 
     beforeEach(() => {
       state = {
@@ -29,7 +52,9 @@ describe("QiitaModule", () => {
         qiitaAccountId: "test-user",
         permanentId: "1",
         sessionId: "",
-        categories: []
+        categories: [],
+        stocks: stocks,
+        paging: []
       };
     });
 
@@ -75,6 +100,13 @@ describe("QiitaModule", () => {
 
       expect(categories).toEqual(state.categories);
     });
+
+    it("should be able to get stocks", () => {
+      const wrapper = (getters: any) => getters.stocks(state);
+      const stocks: IQiitaState["stocks"] = wrapper(QiitaModule.getters);
+
+      expect(stocks).toEqual(state.stocks);
+    });
   });
 
   describe("mutations", () => {
@@ -87,7 +119,9 @@ describe("QiitaModule", () => {
         qiitaAccountId: "",
         permanentId: "",
         sessionId: "",
-        categories: []
+        categories: [],
+        stocks: [],
+        paging: []
       };
     });
 
@@ -190,6 +224,63 @@ describe("QiitaModule", () => {
       wrapper(QiitaModule.mutations);
 
       expect(state.categories[0].name).toEqual(updateCategory.categoryName);
+    });
+
+    it("should be able to save stocks", () => {
+      const stocks: IStock[] = [
+        {
+          id: "1",
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"]
+        },
+        {
+          id: "2",
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"]
+        }
+      ];
+      const wrapper = (mutations: any) => mutations.saveStocks(state, stocks);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.stocks).toEqual(stocks);
+    });
+
+    it("should be able to save paging", () => {
+      const paging: IPage[] = [
+        {
+          page: "4",
+          perPage: "20",
+          relation: "next"
+        },
+        {
+          page: "5",
+          perPage: "20",
+          relation: "last"
+        },
+        {
+          page: "1",
+          perPage: "20",
+          relation: "first"
+        },
+        {
+          page: "2",
+          perPage: "20",
+          relation: "prev"
+        }
+      ];
+
+      const wrapper = (mutations: any) => mutations.savePaging(state, paging);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.paging).toEqual(paging);
     });
   });
 
@@ -432,6 +523,78 @@ describe("QiitaModule", () => {
 
       expect(commit.mock.calls).toEqual([
         ["updateCategory", updateCategoryItem]
+      ]);
+    });
+
+    it("should be able to fetch stocks", async () => {
+      const stocks: IStock[] = [
+        {
+          id: "1",
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"]
+        },
+        {
+          id: "2",
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"]
+        }
+      ];
+
+      const paging: IPage[] = [
+        {
+          page: "4",
+          perPage: "20",
+          relation: "next"
+        },
+        {
+          page: "5",
+          perPage: "20",
+          relation: "last"
+        },
+        {
+          page: "1",
+          perPage: "20",
+          relation: "first"
+        },
+        {
+          page: "2",
+          perPage: "20",
+          relation: "prev"
+        }
+      ];
+
+      const link =
+        '<http://127.0.0.1/api/stocks?page=4&per_page=20>; rel="next",' +
+        '<http://127.0.0.1/api/stocks?page=5&per_page=20>; rel="last",' +
+        '<http://127.0.0.1/api/stocks?page=1&per_page=20>; rel="first",' +
+        '<http://127.0.0.1/api/stocks?page=2&per_page=20>; rel="prev"';
+
+      const mockResponse: { data: any; headers: any } = {
+        data: stocks,
+        headers: {
+          link: link
+        }
+      };
+
+      const mockAxios: any = axios;
+      mockAxios.get.mockResolvedValue(mockResponse);
+
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) => actions.fetchStock({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([
+        ["saveStocks", stocks],
+        ["savePaging", paging]
       ]);
     });
   });

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -25,7 +25,9 @@ describe("SignUp.vue", () => {
       qiitaAccountId: "",
       permanentId: "",
       sessionId: "-0a4e-4f14-a5c5-f4303fbd8a08",
-      categories: []
+      categories: [],
+      stocks: [],
+      paging: []
     };
 
     actions = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/95

# Doneの定義
- ストック取得APIととフロントエンドが通信できていること

# 変更点概要

## 仕様的変更点概要
ログイン後の画面表示後、ストック同期APIのリクエスト後にストック取得APIへリクエストする処理を追加。

## 技術的変更点概要
ModuleのActionに、ストック取得APIへのリクエスト処理を追加。
Accountコンポーネントから呼び出している。

APIから取得したストック一覧とLinkの情報は、Stateに保存している。

# 補足情報
ページング処理については、別のIssueを立てて対応する。