### PR TITLE
ログアウト処理を作成する

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -26,7 +26,7 @@
               <a class="navbar-link">アカウント</a>
               <div class="navbar-dropdown is-right">
                 <a class="navbar-item" href="/cancel">設定</a>
-                <a class="navbar-item">ログアウト</a>
+                <a class="navbar-item" @click="logout">ログアウト</a>
               </div>
             </div>
           </div>
@@ -38,14 +38,18 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { Getter, namespace } from "vuex-class";
+import { Getter, Action, namespace } from "vuex-class";
 
+const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
 
 @Component
 export default class AppHeader extends Vue {
   @QiitaGetter
   isLoggedIn!: boolean;
+
+  @QiitaAction
+  logout!: () => void;
 
   isMenuActive: boolean = false;
 

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -23,6 +23,7 @@ export interface IQiitaStockerApi {
   issueLoginSession(
     request: IIssueLoginSessionRequest
   ): Promise<IIssueLoginSessionResponse>;
+  logout(request: ILogoutRequest): Promise<void>;
   fetchCategories(
     request: IFetchCategoriesRequest
   ): Promise<IFetchCategoriesResponse[]>;
@@ -95,6 +96,11 @@ export interface IIssueLoginSessionRequest {
 }
 
 export interface IIssueLoginSessionResponse {
+  sessionId: string;
+}
+
+export interface ILogoutRequest {
+  apiUrlBase: string;
   sessionId: string;
 }
 
@@ -210,6 +216,10 @@ export const cancelAccount = async (
   request: ICancelAccountRequest
 ): Promise<void> => {
   return await qiitaStockerApi.cancelAccount(request);
+};
+
+export const logout = async (request: ILogoutRequest): Promise<void> => {
+  return await qiitaStockerApi.logout(request);
 };
 
 export const saveCategory = async (

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -16,7 +16,8 @@ import {
   ISynchronizeStockRequest,
   IFetchStockRequest,
   IFetchStockResponse,
-  IPage
+  IPage,
+  ILogoutRequest
 } from "@/domain/qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -79,6 +80,21 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
       )
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve(axiosResponse.data);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async logout(request: ILogoutRequest): Promise<void> {
+    return await axios
+      .delete(`${request.apiUrlBase}/api/login-sessions`, {
+        headers: {
+          Authorization: `Bearer ${request.sessionId}`
+        }
+      })
+      .then(() => {
+        return Promise.resolve();
       })
       .catch((axiosError: IQiitaStockerError) => {
         return Promise.reject(axiosError);

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -301,6 +301,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       await logout(logoutRequest);
 
       localStorage.remove(STORAGE_KEY_SESSION_ID);
+      commit("saveSessionId", "");
 
       router.push({
         name: "home"

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -436,6 +436,17 @@ const actions: ActionTree<IQiitaState, RootState> = {
       });
       return;
     }
+  },
+  logout: async ({ commit }) => {
+    try {
+      // TODO ログアウト処理を作成
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
   }
 };
 

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -325,6 +325,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       await cancelAccount(cancelAccountRequest);
 
       localStorage.remove(STORAGE_KEY_SESSION_ID);
+      commit("saveSessionId", "");
 
       router.push({
         name: "cancelComplete"

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -42,7 +42,9 @@ import {
   IFetchStockResponse,
   fetchStocks,
   IStock,
-  IPage
+  IPage,
+  ILogoutRequest,
+  logout
 } from "@/domain/qiita";
 import uuid from "uuid";
 import router from "@/router";
@@ -288,6 +290,29 @@ const actions: ActionTree<IQiitaState, RootState> = {
       return;
     }
   },
+  logout: async ({ commit }) => {
+    try {
+      const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+      const logoutRequest: ILogoutRequest = {
+        apiUrlBase: apiUrlBase(),
+        sessionId: sessionId
+      };
+
+      await logout(logoutRequest);
+
+      localStorage.remove(STORAGE_KEY_SESSION_ID);
+
+      router.push({
+        name: "home"
+      });
+    } catch (error) {
+      router.push({
+        name: "error",
+        params: { errorMessage: error.response.data.message }
+      });
+      return;
+    }
+  },
   cancel: async ({ commit }) => {
     try {
       const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
@@ -429,17 +454,6 @@ const actions: ActionTree<IQiitaState, RootState> = {
 
       commit("saveStocks", fetchStockResponse.stocks);
       commit("savePaging", fetchStockResponse.paging);
-    } catch (error) {
-      router.push({
-        name: "error",
-        params: { errorMessage: error.response.data.message }
-      });
-      return;
-    }
-  },
-  logout: async ({ commit }) => {
-    try {
-      // TODO ログアウト処理を作成
     } catch (error) {
       router.push({
         name: "error",

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -64,4 +64,27 @@ describe("AppHeader.vue", () => {
     const navbarItem = wrapper.findAll("a").at(4);
     expect(navbarItem.text()).toBe("ログアウト");
   });
+
+  it('calls store action "logout" when logoutLink is clicked', () => {
+    const actions = {
+      logout: jest.fn()
+    };
+
+    store = new Vuex.Store({
+      modules: {
+        QiitaModule: {
+          namespaced: true,
+          state,
+          actions,
+          getters: QiitaModule.getters
+        }
+      }
+    });
+
+    const wrapper = shallowMount(AppHeader, { store, localVue, router });
+    const logoutLink = wrapper.findAll("a").at(4);
+
+    logoutLink.trigger("click");
+    expect(actions.logout).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -417,6 +417,17 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([["saveSessionId", sessionId]]);
     });
 
+    it("should be able to logout", async () => {
+      const mockAxios: any = axios;
+      mockAxios.delete.mockResolvedValue({});
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) => actions.logout({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["saveSessionId", ""]]);
+    });
+
     it("should not commit when callbackState don't match localState", async () => {
       const commit = jest.fn();
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -428,6 +428,17 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([["saveSessionId", ""]]);
     });
 
+    it("should be able to cancel", async () => {
+      const mockAxios: any = axios;
+      mockAxios.delete.mockResolvedValue({});
+      const commit = jest.fn();
+
+      const wrapper = (actions: any) => actions.cancel({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["saveSessionId", ""]]);
+    });
+
     it("should not commit when callbackState don't match localState", async () => {
       const commit = jest.fn();
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/100

# Doneの定義
- ログアウトAPIとフロントエンドが通信できていること
- ローカルストレージからログインセッションが削除されていること

# 変更点概要

## 仕様的変更点概要
ヘッダーのログアウトを押下時に、以下の処理を実行
- ログアウトAPIへのリクエスト
-  ローカルストレージからログインセッションを削除

今回のIssueとは関係ないが、退会時についてもローカルストレージからログインセッションを削除する処理を追加。

## 技術的変更点概要
ModuleのActionにログアウト処理を追加。
`AppHeader`コンポーネントより、上記Actionを呼び出している。