### PR TITLE
カテゴライズのUIを設計する

### DIFF
--- a/src/components/Stock.vue
+++ b/src/components/Stock.vue
@@ -30,6 +30,9 @@
         </div>
       </div>
     </div>
+    <label v-show="isCategorizing" class="checkbox checkbox-size">
+      <input type="checkbox" />
+    </label>
   </article>
 </template>
 
@@ -41,10 +44,17 @@ import { IStock } from "@/domain/qiita";
 export default class Stock extends Vue {
   @Prop()
   stock!: IStock[];
+
+  @Prop()
+  isCategorizing!: boolean;
 }
 </script>
 
 <style scoped>
+.checkbox-size {
+  zoom: 3;
+}
+
 a {
   color: #337ab7;
 }

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="navbar-menu">
+    <div class="navbar-end">
+      <div v-if="isCategorizing">
+        <div class="select edit-header">
+          <select v-model="selectedCategoryId">
+            <option
+              v-for="category in categories"
+              :value="category.categoryId"
+              :key="category.categoryId"
+              >{{ category.name }}</option
+            >
+          </select>
+        </div>
+        <button class="button is-danger" @click="changeCategory">保存</button>
+        <button class="button is-white has-text-grey" @click="cancel">
+          キャンセル
+        </button>
+      </div>
+      <div v-else>
+        <button class="button is-light" @click="startEdit">
+          カテゴリに分類する
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { IStock } from "@/domain/qiita";
+import { ICategory } from "@/domain/qiita";
+
+@Component
+export default class StockEdit extends Vue {
+  @Prop()
+  isCategorizing!: boolean;
+
+  @Prop()
+  categories!: ICategory[];
+
+  selectedCategoryId: number = 0;
+
+  doneEdit() {
+    this.$emit("clickSetIsCategorizing");
+  }
+
+  startEdit() {
+    this.doneEdit();
+  }
+
+  cancel() {
+    this.doneEdit();
+  }
+
+  changeCategory() {
+    // TODO ストックをカテゴライズするAPIを呼び出す
+    this.doneEdit();
+  }
+}
+</script>
+
+<style scoped>
+.edit-header {
+  margin-right: 10px;
+}
+</style>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -28,7 +28,6 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-import { IStock } from "@/domain/qiita";
 import { ICategory } from "@/domain/qiita";
 
 @Component

--- a/src/components/StockList.vue
+++ b/src/components/StockList.vue
@@ -6,6 +6,7 @@
         v-for="stock in stocks"
         :stock="stock"
         :key="stock.id"
+        :isCategorizing="isCategorizing"
       />
     </div>
     <div v-else><h1 class="subtitle">ストックされた記事はありません。</h1></div>
@@ -25,5 +26,8 @@ import { IStock } from "@/domain/qiita";
 export default class StockList extends Vue {
   @Prop()
   stocks!: IStock[];
+
+  @Prop()
+  isCategorizing!: boolean;
 }
 </script>

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -12,12 +12,13 @@
         </div>
         <div class="column is-9">
           <StockEdit
+            v-show="stocks.length"
             :isCategorizing="isCategorizing"
             :categories="categories"
             @clickSetIsCategorizing="onSetIsCategorizing"
           />
           <StockList :stocks="stocks" :isCategorizing="isCategorizing" />
-          <Pagination />
+          <Pagination v-show="stocks.length" />
         </div>
       </div>
     </main>

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -11,7 +11,13 @@
           />
         </div>
         <div class="column is-9">
-          <StockList :stocks="stocks" /> <Pagination />
+          <StockEdit
+            :isCategorizing="isCategorizing"
+            :categories="categories"
+            @clickSetIsCategorizing="onSetIsCategorizing"
+          />
+          <StockList :stocks="stocks" :isCategorizing="isCategorizing" />
+          <Pagination />
         </div>
       </div>
     </main>
@@ -24,6 +30,7 @@ import { Getter, Action, namespace } from "vuex-class";
 
 import AppHeader from "@/components/AppHeader.vue";
 import SideMenu from "@/components/SideMenu.vue";
+import StockEdit from "@/components/StockEdit.vue";
 import StockList from "@/components/StockList.vue";
 import Pagination from "@/components/Pagination.vue";
 import { IStock, ICategory } from "@/domain/qiita";
@@ -36,6 +43,7 @@ const QiitaGetter = namespace("QiitaModule", Getter);
   components: {
     AppHeader,
     SideMenu,
+    StockEdit,
     StockList,
     Pagination
   }
@@ -46,6 +54,9 @@ export default class Account extends Vue {
 
   @QiitaGetter
   stocks!: IStock[];
+
+  @QiitaGetter
+  isCategorizing!: boolean;
 
   @QiitaAction
   saveCategory!: (category: string) => void;
@@ -61,6 +72,9 @@ export default class Account extends Vue {
 
   @QiitaAction
   fetchStock!: () => void;
+
+  @QiitaAction
+  setIsCategorizing!: () => void;
 
   onClickSaveCategory(categoryName: string) {
     this.saveCategory(categoryName);
@@ -84,6 +98,10 @@ export default class Account extends Vue {
   async initializeStock() {
     await this.synchronizeStock();
     await this.fetchStock();
+  }
+
+  onSetIsCategorizing() {
+    this.setIsCategorizing();
   }
 }
 </script>

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -90,7 +90,7 @@ const state: IQiitaState = {
   categories: [],
   stocks: [],
   paging: [],
-  isCategorizing: true
+  isCategorizing: false
 };
 
 const getters: GetterTree<IQiitaState, RootState> = {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -89,7 +89,8 @@ const state: IQiitaState = {
   sessionId: localStorage.load(STORAGE_KEY_SESSION_ID) || "",
   categories: [],
   stocks: [],
-  paging: []
+  paging: [],
+  isCategorizing: true
 };
 
 const getters: GetterTree<IQiitaState, RootState> = {
@@ -110,6 +111,9 @@ const getters: GetterTree<IQiitaState, RootState> = {
   },
   stocks: (state): IQiitaState["stocks"] => {
     return state.stocks;
+  },
+  isCategorizing: (state): IQiitaState["isCategorizing"] => {
+    return state.isCategorizing;
   }
 };
 
@@ -146,6 +150,9 @@ const mutations: MutationTree<IQiitaState> = {
   },
   savePaging: (state, paging: IPage[]) => {
     state.paging = paging;
+  },
+  setIsCategorizing: state => {
+    state.isCategorizing = !state.isCategorizing;
   }
 };
 
@@ -463,6 +470,9 @@ const actions: ActionTree<IQiitaState, RootState> = {
       });
       return;
     }
+  },
+  setIsCategorizing: async ({ commit }) => {
+    commit("setIsCategorizing");
   }
 };
 

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -9,4 +9,5 @@ export interface IQiitaState {
   categories: ICategory[];
   stocks: IStock[];
   paging: IPage[];
+  isCategorizing: boolean;
 }

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -30,7 +30,8 @@ describe("Account.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
-      paging: []
+      paging: [],
+      isCategorizing: false
     };
 
     actions = {

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import { IUpdateCategoryPayload, QiitaModule } from "@/store/modules/qiita";
 import Account from "@/pages/Account.vue";
 import SideMenu from "@/components/SideMenu.vue";
+import StockEdit from "@/components/StockEdit.vue";
 import CategoryList from "@/components/CategoryList.vue";
 import { IQiitaState } from "@/types/qiita";
 import VueRouter from "vue-router";
@@ -38,7 +39,9 @@ describe("Account.vue", () => {
       saveCategory: jest.fn(),
       updateCategory: jest.fn(),
       fetchCategory: jest.fn(),
-      synchronizeStock: jest.fn()
+      synchronizeStock: jest.fn(),
+      fetchStock: jest.fn(),
+      setIsCategorizing: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -105,6 +108,16 @@ describe("Account.vue", () => {
       wrapper.vm.initializeStock();
 
       expect(actions.synchronizeStock).toHaveBeenCalled();
+      expect(actions.fetchStock).toHaveBeenCalled();
+    });
+
+    it('calls store action "synchronizeStock" on onSetIsCategorizing()', () => {
+      const wrapper = shallowMount(Account, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.onSetIsCategorizing();
+
+      expect(actions.setIsCategorizing).toHaveBeenCalled();
     });
   });
 
@@ -126,29 +139,45 @@ describe("Account.vue", () => {
 
       expect(mock).toHaveBeenCalledWith(inputtedCategory);
     });
-  });
 
-  it("should call onClickUpdateCategory when button is clicked", () => {
-    state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
+    it("should call onClickUpdateCategory when button is clicked", () => {
+      state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
 
-    const mock = jest.fn();
-    const wrapper = mount(Account, { store, localVue, router });
+      const mock = jest.fn();
+      const wrapper = mount(Account, { store, localVue, router });
 
-    wrapper.setMethods({
-      onClickUpdateCategory: mock
+      wrapper.setMethods({
+        onClickUpdateCategory: mock
+      });
+
+      const categoryList = wrapper.find(CategoryList);
+      const editedCategory = "編集されたカテゴリ名";
+
+      const updateCategoryPayload: IUpdateCategoryPayload = {
+        stateCategory: state.categories[0],
+        categoryName: editedCategory
+      };
+
+      // @ts-ignore
+      categoryList.vm.onClickUpdateCategory(updateCategoryPayload);
+
+      expect(mock).toHaveBeenCalledWith(updateCategoryPayload);
     });
 
-    const categoryList = wrapper.find(CategoryList);
-    const editedCategory = "編集されたカテゴリ名";
+    it("should call onSetIsCategorizing when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(Account, { store, localVue, router });
 
-    const updateCategoryPayload: IUpdateCategoryPayload = {
-      stateCategory: state.categories[0],
-      categoryName: editedCategory
-    };
+      wrapper.setMethods({
+        onSetIsCategorizing: mock
+      });
 
-    // @ts-ignore
-    categoryList.vm.onClickUpdateCategory(updateCategoryPayload);
+      const sideMenu = wrapper.find(StockEdit);
 
-    expect(mock).toHaveBeenCalledWith(updateCategoryPayload);
+      // @ts-ignore
+      sideMenu.vm.changeCategory();
+
+      expect(mock).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -26,7 +26,8 @@ describe("AppHeader.vue", () => {
     sessionId: "",
     categories: [],
     stocks: [],
-    paging: []
+    paging: [],
+    isCategorizing: false
   };
 
   it("renders login", () => {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -27,7 +27,8 @@ describe("Cancel.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
-      paging: []
+      paging: [],
+      isCategorizing: false
     };
 
     actions = {

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -27,7 +27,8 @@ describe("Login.vue", () => {
       sessionId: "",
       categories: [],
       stocks: [],
-      paging: []
+      paging: [],
+      isCategorizing: false
     };
 
     actions = {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -53,7 +53,8 @@ describe("QiitaModule", () => {
         sessionId: "",
         categories: [],
         stocks: stocks,
-        paging: []
+        paging: [],
+        isCategorizing: false
       };
     });
 
@@ -120,7 +121,8 @@ describe("QiitaModule", () => {
         sessionId: "",
         categories: [],
         stocks: [],
-        paging: []
+        paging: [],
+        isCategorizing: false
       };
     });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -107,6 +107,15 @@ describe("QiitaModule", () => {
 
       expect(stocks).toEqual(state.stocks);
     });
+
+    it("should be able to get isCategorizing", () => {
+      const wrapper = (getters: any) => getters.isCategorizing(state);
+      const isCategorizing: IQiitaState["isCategorizing"] = wrapper(
+        QiitaModule.getters
+      );
+
+      expect(isCategorizing).toEqual(state.isCategorizing);
+    });
   });
 
   describe("mutations", () => {
@@ -282,6 +291,12 @@ describe("QiitaModule", () => {
       wrapper(QiitaModule.mutations);
 
       expect(state.paging).toEqual(paging);
+    });
+
+    it("should be able to save isCategorizing", () => {
+      const wrapper = (mutations: any) => mutations.setIsCategorizing(state);
+      wrapper(QiitaModule.mutations);
+      expect(state.isCategorizing).toEqual(true);
     });
   });
 
@@ -619,6 +634,14 @@ describe("QiitaModule", () => {
         ["saveStocks", stocks],
         ["savePaging", paging]
       ]);
+    });
+
+    it("should be able to set isCategorizing", async () => {
+      const commit = jest.fn();
+      const wrapper = (actions: any) => actions.setIsCategorizing({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["setIsCategorizing"]]);
     });
   });
 });

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -27,7 +27,8 @@ describe("SignUp.vue", () => {
       sessionId: "-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
-      paging: []
+      paging: [],
+      isCategorizing: false
     };
 
     actions = {

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -1,0 +1,121 @@
+import { shallowMount } from "@vue/test-utils";
+import StockEdit from "@/components/StockEdit.vue";
+import { ICategory } from "@/domain/qiita";
+
+describe("StockEdit.vue", () => {
+  const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
+    isCategorizing: false,
+    categories: [
+      { categoryId: 1, name: "テストカテゴリ1" },
+      { categoryId: 2, name: "テストカテゴリ2" }
+    ]
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(StockEdit, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickSetIsCategorizing on startEdit()", () => {
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.doneEdit();
+      expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
+    });
+
+    it("should emit clickSetIsCategorizing on startEdit()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.startEdit();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should emit clickSetIsCategorizing on cancel()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.cancel();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should emit clickSetIsCategorizing on changeCategory()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(mock).toBeTruthy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call startEdit when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({
+        startEdit: mock
+      });
+
+      wrapper.find("button").trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call changeCategory when button is clicked", () => {
+      const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
+        isCategorizing: true,
+        categories: [
+          { categoryId: 1, name: "テストカテゴリ1" },
+          { categoryId: 2, name: "テストカテゴリ2" }
+        ]
+      };
+
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({
+        changeCategory: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(0)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call cancel when button is clicked", () => {
+      const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
+        isCategorizing: true,
+        categories: [
+          { categoryId: 1, name: "テストカテゴリ1" },
+          { categoryId: 2, name: "テストカテゴリ2" }
+        ]
+      };
+
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({
+        cancel: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/120

# Doneの定義
- 記事をカテゴライズ可能なUIが作成されていること

# スクリーンショット
- `カテゴリに分類する`ボタンを追加
<img width="909" alt="2018-12-23 12 08 28" src="https://user-images.githubusercontent.com/32682645/50380468-81e5b500-06ab-11e9-9225-92b250ba8764.png">

-  `カテゴリに分類する`ボタン押下時のイメージ
<img width="423" alt="2018-12-23 12 09 00" src="https://user-images.githubusercontent.com/32682645/50380472-9164fe00-06ab-11e9-854f-3de085d72c97.png">

# 変更点概要

## 仕様的変更点概要
`カテゴリに分類する`ボタンをストック上部に表示。
ボタン押下により、カテゴライズ一覧のプルダウンメニューとストックの右側にチェックボックスを表示している。
ストックのチェックボックスを選択肢し、プルダウンからカテゴリを選択後に保存ボタンを押下することでカテゴリに紐付けを行う。

## 技術的変更点概要
`StockEdit`コンポーネントを作成。
`State`に、カテゴライズ中かどうかを判定するために`isCategorizing`を追加。
Moduleとコンポーネントのテストケースを追加している。