### PR TITLE
リンクの修正

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -7,6 +7,7 @@
             <ul>
               <li><a href="#">利用規約</a></li>
               <li><a href="#">プライバシーポリシー</a></li>
+              <li><a href="/cancel">退会</a></li>
             </ul>
           </div>
         </div>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -25,7 +25,7 @@
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">アカウント</a>
               <div class="navbar-dropdown is-right">
-                <a class="navbar-item" href="/cancel">設定</a>
+                <a class="navbar-item" href="/stocks/all">ストック一覧</a>
                 <a class="navbar-item" @click="logout">ログアウト</a>
               </div>
             </div>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -23,7 +23,7 @@
           </div>
           <div class="navbar-end" v-else>
             <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link">アカウント</a>
+              <a class="navbar-link">メニュー</a>
               <div class="navbar-dropdown is-right">
                 <a class="navbar-item" href="/stocks/all">ストック一覧</a>
                 <a class="navbar-item" @click="logout">ログアウト</a>

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -49,7 +49,7 @@ const QiitaGetter = namespace("QiitaModule", Getter);
     Pagination
   }
 })
-export default class Account extends Vue {
+export default class Stocks extends Vue {
   @QiitaGetter
   categories!: ICategory[];
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -44,8 +44,8 @@ export default new Router({
       component: SignUp
     },
     {
-      path: "/account",
-      name: "account",
+      path: "/stocks/all",
+      name: "stocks",
       component: Account
     },
     {

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,7 +4,7 @@ import Counter from "./pages/Counter.vue";
 import Weather from "./pages/Weather.vue";
 import SignUp from "./pages/SignUp.vue";
 import Login from "./pages/Login.vue";
-import Account from "./pages/Account.vue";
+import Account from "./pages/Stocks.vue";
 import OAuthCallback from "./pages/oAuth/callback/OAuthCallback.vue";
 import Cancel from "./pages/cencel/Cancel.vue";
 import CancelComplete from "./pages/cencel/complete/CancelComplete.vue";

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -256,7 +256,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       );
 
       router.push({
-        name: "account"
+        name: "stocks"
       });
     } catch (error) {
       router.push({
@@ -287,7 +287,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       );
 
       router.push({
-        name: "account"
+        name: "stocks"
       });
     } catch (error) {
       router.push({

--- a/tests/unit/Account.spec.ts
+++ b/tests/unit/Account.spec.ts
@@ -1,7 +1,7 @@
 import { shallowMount, mount, createLocalVue, config } from "@vue/test-utils";
 import Vuex from "vuex";
 import { IUpdateCategoryPayload, QiitaModule } from "@/store/modules/qiita";
-import Account from "@/pages/Account.vue";
+import Stocks from "@/pages/Stocks.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import StockEdit from "@/components/StockEdit.vue";
 import CategoryList from "@/components/CategoryList.vue";
@@ -17,7 +17,7 @@ localVue.use(VueRouter);
 
 const router = new VueRouter();
 
-describe("Account.vue", () => {
+describe("Stocks.vue", () => {
   let store: any;
   let state: IQiitaState;
   let actions: any;
@@ -58,7 +58,7 @@ describe("Account.vue", () => {
 
   describe("methods", () => {
     it('calls store action "saveCategory" on onClickSaveCategory()', () => {
-      const wrapper = shallowMount(Account, { store, localVue, router });
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
       const inputtedCategory = "inputtedCategory";
 
       // @ts-ignore
@@ -74,7 +74,7 @@ describe("Account.vue", () => {
     it('calls store action "updateCategory" on onClickUpdateCategory()', () => {
       state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
 
-      const wrapper = shallowMount(Account, { store, localVue, router });
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
       const editedCategory = "編集されたカテゴリ名";
 
       const updateCategoryPayload: IUpdateCategoryPayload = {
@@ -93,7 +93,7 @@ describe("Account.vue", () => {
     });
 
     it('calls store action "fetchCategory" on initializeCategory()', () => {
-      const wrapper = shallowMount(Account, { store, localVue, router });
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
 
       // @ts-ignore
       wrapper.vm.initializeCategory();
@@ -102,7 +102,7 @@ describe("Account.vue", () => {
     });
 
     it('calls store action "synchronizeStock" on initializeStock()', () => {
-      const wrapper = shallowMount(Account, { store, localVue, router });
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
 
       // @ts-ignore
       wrapper.vm.initializeStock();
@@ -112,7 +112,7 @@ describe("Account.vue", () => {
     });
 
     it('calls store action "synchronizeStock" on onSetIsCategorizing()', () => {
-      const wrapper = shallowMount(Account, { store, localVue, router });
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
 
       // @ts-ignore
       wrapper.vm.onSetIsCategorizing();
@@ -125,7 +125,7 @@ describe("Account.vue", () => {
   describe("template", () => {
     it("should call onClickSaveCategory when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = mount(Account, { store, localVue, router });
+      const wrapper = mount(Stocks, { store, localVue, router });
 
       wrapper.setMethods({
         onClickSaveCategory: mock
@@ -144,7 +144,7 @@ describe("Account.vue", () => {
       state.categories = [{ categoryId: 1, name: "テストカテゴリ" }];
 
       const mock = jest.fn();
-      const wrapper = mount(Account, { store, localVue, router });
+      const wrapper = mount(Stocks, { store, localVue, router });
 
       wrapper.setMethods({
         onClickUpdateCategory: mock
@@ -166,7 +166,7 @@ describe("Account.vue", () => {
 
     it("should call onSetIsCategorizing when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = mount(Account, { store, localVue, router });
+      const wrapper = mount(Stocks, { store, localVue, router });
 
       wrapper.setMethods({
         onSetIsCategorizing: mock


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/138

# Doneの定義
- ヘッダーのストック一覧のリンクが/stacks/allに修正されていること
- 退会のリンクがフッターに追加されていること

# スクリーンショット
### ヘッダー
<img width="275" alt="2018-12-24 13 46 20" src="https://user-images.githubusercontent.com/32682645/50391075-84670e00-0782-11e9-9765-e91c8944e17c.png">

### フッター
<img width="366" alt="2018-12-24 13 48 17" src="https://user-images.githubusercontent.com/32682645/50391079-9943a180-0782-11e9-8f2d-c79a5aedeced.png">

# 変更点概要

## 仕様的変更点概要
リンクを修正
- ヘッダーの[ストック一覧] -> `/stocks/all` ストック一覧画面に遷移
- フッターの[退会] -> `/cancel` 退会画面に遷移

## 技術的変更点概要
ルーティングを修正。
コンポーネント名が内容に合っていなかったので、`Account.vue` -> `Stocks.vue`に修正。