### PR TITLE
カテゴライズAPIへのリクエスト処理を作成する

### DIFF
--- a/src/components/Stock.vue
+++ b/src/components/Stock.vue
@@ -31,22 +31,30 @@
       </div>
     </div>
     <label v-show="isCategorizing" class="checkbox checkbox-size">
-      <input type="checkbox" />
+      <input
+        type="checkbox"
+        :checked="stock.isChecked"
+        @change="onClickCheckStock(stock);"
+      />
     </label>
   </article>
 </template>
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
-import { IStock } from "@/domain/qiita";
+import { IUncategorizedStock } from "@/domain/qiita";
 
 @Component
 export default class Stock extends Vue {
   @Prop()
-  stock!: IStock[];
+  stock!: IUncategorizedStock[];
 
   @Prop()
   isCategorizing!: boolean;
+
+  onClickCheckStock(stock: IUncategorizedStock) {
+    this.$emit("clickCheckStock", stock);
+  }
 }
 </script>
 

--- a/src/components/Stock.vue
+++ b/src/components/Stock.vue
@@ -34,7 +34,7 @@
       <input
         type="checkbox"
         :checked="stock.isChecked"
-        @change="onClickCheckStock(stock);"
+        @change="onClickCheckStock"
       />
     </label>
   </article>
@@ -52,8 +52,8 @@ export default class Stock extends Vue {
   @Prop()
   isCategorizing!: boolean;
 
-  onClickCheckStock(stock: IUncategorizedStock) {
-    this.$emit("clickCheckStock", stock);
+  onClickCheckStock() {
+    this.$emit("clickCheckStock", this.stock);
   }
 }
 </script>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -53,7 +53,8 @@ export default class StockEdit extends Vue {
   }
 
   changeCategory() {
-    // TODO ストックをカテゴライズするAPIを呼び出す
+    // TODO カテゴリが選択されていなかった場合エラーを表示する
+    this.$emit("clickCategorize", this.selectedCategoryId);
     this.doneEdit();
   }
 }

--- a/src/components/StockList.vue
+++ b/src/components/StockList.vue
@@ -5,8 +5,9 @@
         v-if="stocks.length"
         v-for="stock in stocks"
         :stock="stock"
-        :key="stock.id"
+        :key="stock.article_id"
         :isCategorizing="isCategorizing"
+        @clickCheckStock="onClickCheckStock"
       />
     </div>
     <div v-else><h1 class="subtitle">ストックされた記事はありません。</h1></div>
@@ -16,7 +17,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import Stock from "@/components/Stock.vue";
-import { IStock } from "@/domain/qiita";
+import { IUncategorizedStock } from "@/domain/qiita";
 
 @Component({
   components: {
@@ -25,9 +26,13 @@ import { IStock } from "@/domain/qiita";
 })
 export default class StockList extends Vue {
   @Prop()
-  stocks!: IStock[];
+  stocks!: IUncategorizedStock[];
 
   @Prop()
   isCategorizing!: boolean;
+
+  onClickCheckStock(stock: IUncategorizedStock) {
+    this.$emit("clickCheckStock", stock);
+  }
 }
 </script>

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -173,13 +173,16 @@ export interface ICategory {
 }
 
 export interface IStock {
-  id: string;
   article_id: string;
   title: string;
   user_id: string;
   profile_image_url: string;
   article_created_at: string;
   tags: string[];
+}
+
+export interface IUncategorizedStock extends IStock {
+  isChecked: boolean;
 }
 
 export const requestToAuthorizationServer = (

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -32,6 +32,7 @@ export interface IQiitaStockerApi {
     request: IUpdateCategoryRequest
   ): Promise<IUpdateCategoryResponse>;
   fetchStocks(request: IFetchStockRequest): Promise<IFetchStockResponse>;
+  categorize(request: ICategorizeRequest): Promise<void>;
 }
 
 export interface IQiitaApi {
@@ -144,6 +145,13 @@ export interface IFetchStockRequest {
   parPage: string;
 }
 
+export interface ICategorizeRequest {
+  apiUrlBase: string;
+  sessionId: string;
+  categoryId: number;
+  articleIds: string[];
+}
+
 export interface IPage {
   page: string;
   perPage: string;
@@ -238,6 +246,12 @@ export const fetchStocks = async (
   request: IFetchStockRequest
 ): Promise<IFetchStockResponse> => {
   return await qiitaStockerApi.fetchStocks(request);
+};
+
+export const categorize = async (
+  request: ICategorizeRequest
+): Promise<void> => {
+  return await qiitaStockerApi.categorize(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -16,7 +16,8 @@ import {
   IFetchStockRequest,
   IFetchStockResponse,
   IPage,
-  ILogoutRequest
+  ILogoutRequest,
+  ICategorizeRequest
 } from "@/domain/qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -104,7 +105,7 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
     request: IFetchCategoriesRequest
   ): Promise<IFetchCategoriesResponse[]> {
     return await axios
-      .get<IFetchCategoriesRequest>(`${request.apiUrlBase}/api/categories`, {
+      .get<IFetchCategoriesResponse[]>(`${request.apiUrlBase}/api/categories`, {
         headers: {
           Authorization: `Bearer ${request.sessionId}`
         }
@@ -163,7 +164,7 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
 
   async fetchStocks(request: IFetchStockRequest): Promise<IFetchStockResponse> {
     return await axios
-      .get<IFetchStockRequest>(
+      .get<IFetchStockResponse>(
         `${request.apiUrlBase}/api/stocks?page=${request.page}&per_page=${
           request.parPage
         }`,
@@ -183,6 +184,29 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
         };
 
         return Promise.resolve(response);
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async categorize(request: ICategorizeRequest): Promise<void> {
+    return await axios
+      .post(
+        `${request.apiUrlBase}/api/categories/stocks`,
+        {
+          id: request.categoryId,
+          articleIds: request.articleIds
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`,
+            "Content-Type": "application/json"
+          }
+        }
+      )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve();
       })
       .catch((axiosError: IQiitaStockerError) => {
         return Promise.reject(axiosError);

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -16,6 +16,7 @@
             :isCategorizing="isCategorizing"
             :categories="categories"
             @clickSetIsCategorizing="onSetIsCategorizing"
+            @clickCategorize="onClickCategorize"
           />
           <StockList :stocks="stocks" :isCategorizing="isCategorizing" />
           <Pagination v-show="stocks.length" />
@@ -74,12 +75,19 @@ export default class Stocks extends Vue {
   @QiitaAction
   setIsCategorizing!: () => void;
 
+  @QiitaAction
+  categorize!: (categoryId: number) => void;
+
   onClickSaveCategory(categoryName: string) {
     this.saveCategory(categoryName);
   }
 
   onClickUpdateCategory(updateCategoryPayload: IUpdateCategoryPayload) {
     this.updateCategory(updateCategoryPayload);
+  }
+
+  onClickCategorize(categoryId: number) {
+    this.categorize(categoryId);
   }
 
   created() {

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -18,7 +18,11 @@
             @clickSetIsCategorizing="onSetIsCategorizing"
             @clickCategorize="onClickCategorize"
           />
-          <StockList :stocks="stocks" :isCategorizing="isCategorizing" />
+          <StockList
+            :stocks="stocks"
+            :isCategorizing="isCategorizing"
+            @clickCheckStock="onClickCheckStock"
+          />
           <Pagination v-show="stocks.length" />
         </div>
       </div>
@@ -35,8 +39,11 @@ import SideMenu from "@/components/SideMenu.vue";
 import StockEdit from "@/components/StockEdit.vue";
 import StockList from "@/components/StockList.vue";
 import Pagination from "@/components/Pagination.vue";
-import { IStock, ICategory } from "@/domain/qiita";
-import { IUpdateCategoryPayload } from "@/store/modules/qiita";
+import { ICategory, IUncategorizedStock } from "@/domain/qiita";
+import {
+  IUpdateCategoryPayload,
+  ICategorizePayload
+} from "@/store/modules/qiita";
 
 const QiitaAction = namespace("QiitaModule", Action);
 const QiitaGetter = namespace("QiitaModule", Getter);
@@ -55,10 +62,13 @@ export default class Stocks extends Vue {
   categories!: ICategory[];
 
   @QiitaGetter
-  stocks!: IStock[];
+  stocks!: IUncategorizedStock[];
 
   @QiitaGetter
   isCategorizing!: boolean;
+
+  @QiitaGetter
+  checkedStockArticleIds!: string[];
 
   @QiitaAction
   saveCategory!: (category: string) => void;
@@ -76,7 +86,10 @@ export default class Stocks extends Vue {
   setIsCategorizing!: () => void;
 
   @QiitaAction
-  categorize!: (categoryId: number) => void;
+  categorize!: (categorizePayload: ICategorizePayload) => void;
+
+  @QiitaAction
+  checkStock!: (stock: IUncategorizedStock) => void;
 
   onClickSaveCategory(categoryName: string) {
     this.saveCategory(categoryName);
@@ -87,7 +100,15 @@ export default class Stocks extends Vue {
   }
 
   onClickCategorize(categoryId: number) {
-    this.categorize(categoryId);
+    const categorizePayload: ICategorizePayload = {
+      categoryId: categoryId,
+      stockArticleIds: this.checkedStockArticleIds
+    };
+    this.categorize(categorizePayload);
+  }
+
+  onClickCheckStock(stock: IUncategorizedStock) {
+    this.checkStock(stock);
   }
 
   created() {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -42,7 +42,9 @@ import {
   IStock,
   IPage,
   ILogoutRequest,
-  logout
+  logout,
+  ICategorizeRequest,
+  categorize
 } from "@/domain/qiita";
 import uuid from "uuid";
 import { router } from "@/router";
@@ -454,6 +456,21 @@ const actions: ActionTree<IQiitaState, RootState> = {
   },
   setIsCategorizing: async ({ commit }) => {
     commit("setIsCategorizing");
+  },
+  categorize: async ({ commit }, categoryId: number) => {
+    const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
+    const categorizeRequest: ICategorizeRequest = {
+      apiUrlBase: apiUrlBase(),
+      sessionId: sessionId,
+      categoryId: categoryId,
+      articleIds: [
+        "aaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbb",
+        "cccccccccccccccccccc"
+      ]
+    };
+
+    await categorize(categorizeRequest);
   }
 };
 

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -1,4 +1,4 @@
-import { ICategory, IPage, IStock } from "@/domain/qiita";
+import { ICategory, IPage, IUncategorizedStock } from "@/domain/qiita";
 
 export interface IQiitaState {
   authorizationCode: string;
@@ -7,7 +7,7 @@ export interface IQiitaState {
   permanentId: string;
   sessionId: string;
   categories: ICategory[];
-  stocks: IStock[];
+  stocks: IUncategorizedStock[];
   paging: IPage[];
   isCategorizing: boolean;
 }

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -2,7 +2,8 @@ import { IQiitaState } from "@/types/qiita";
 import {
   ICategory,
   ICreateAccountResponse,
-  IIssueLoginSessionResponse, IUncategorizedStock
+  IIssueLoginSessionResponse,
+  IUncategorizedStock
 } from "@/domain/qiita";
 import { QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
@@ -31,7 +32,7 @@ describe("QiitaModule", () => {
         profile_image_url: "https://test.com/test/image",
         article_created_at: "2018/09/30",
         tags: ["laravel", "php"],
-        isChecked: false
+        isChecked: true
       },
       {
         article_id: "c0a2609ae61a72dcc60f",
@@ -115,6 +116,13 @@ describe("QiitaModule", () => {
       );
 
       expect(isCategorizing).toEqual(state.isCategorizing);
+    });
+
+    it("should be able to get checkedStockArticleIds", () => {
+      const wrapper = (getters: any) => getters.checkedStockArticleIds(state);
+      const checkedStockArticleIds: string[] = wrapper(QiitaModule.getters);
+
+      expect(checkedStockArticleIds).toEqual([state.stocks[0].article_id]);
     });
   });
 
@@ -297,6 +305,23 @@ describe("QiitaModule", () => {
       const wrapper = (mutations: any) => mutations.setIsCategorizing(state);
       wrapper(QiitaModule.mutations);
       expect(state.isCategorizing).toEqual(true);
+    });
+
+    it("should be able to check Stock", () => {
+      const stock: IUncategorizedStock = {
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"],
+        isChecked: false
+      };
+
+      const wrapper = (mutations: any) =>
+        mutations.checkStock(state, { stock, isChecked: true });
+      wrapper(QiitaModule.mutations);
+      expect(stock.isChecked).toEqual(true);
     });
   });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -2,7 +2,7 @@ import { IQiitaState } from "@/types/qiita";
 import {
   ICategory,
   ICreateAccountResponse,
-  IIssueLoginSessionResponse
+  IIssueLoginSessionResponse, IUncategorizedStock
 } from "@/domain/qiita";
 import { QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
@@ -23,24 +23,24 @@ jest.mock("axios");
 describe("QiitaModule", () => {
   describe("getters", () => {
     let state: IQiitaState;
-    const stocks: IStock[] = [
+    const stocks: IUncategorizedStock[] = [
       {
-        id: "1",
         article_id: "c0a2609ae61a72dcc60f",
         title: "title1",
         user_id: "test-user1",
         profile_image_url: "https://test.com/test/image",
         article_created_at: "2018/09/30",
-        tags: ["laravel", "php"]
+        tags: ["laravel", "php"],
+        isChecked: false
       },
       {
-        id: "2",
         article_id: "c0a2609ae61a72dcc60f",
         title: "title2",
         user_id: "test-user12",
         profile_image_url: "https://test.com/test/image",
         article_created_at: "2018/09/30",
-        tags: ["Vue.js", "Vuex", "TypeScript"]
+        tags: ["Vue.js", "Vuex", "TypeScript"],
+        isChecked: false
       }
     ];
 
@@ -237,24 +237,24 @@ describe("QiitaModule", () => {
     });
 
     it("should be able to save stocks", () => {
-      const stocks: IStock[] = [
+      const stocks: IUncategorizedStock[] = [
         {
-          id: "1",
           article_id: "c0a2609ae61a72dcc60f",
           title: "title1",
           user_id: "test-user1",
           profile_image_url: "https://test.com/test/image",
           article_created_at: "2018/09/30",
-          tags: ["laravel", "php"]
+          tags: ["laravel", "php"],
+          isChecked: false
         },
         {
-          id: "2",
           article_id: "c0a2609ae61a72dcc60f",
           title: "title2",
           user_id: "test-user12",
           profile_image_url: "https://test.com/test/image",
           article_created_at: "2018/09/30",
-          tags: ["Vue.js", "Vuex", "TypeScript"]
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false
         }
       ];
       const wrapper = (mutations: any) => mutations.saveStocks(state, stocks);
@@ -567,7 +567,6 @@ describe("QiitaModule", () => {
     it("should be able to fetch stocks", async () => {
       const stocks: IStock[] = [
         {
-          id: "1",
           article_id: "c0a2609ae61a72dcc60f",
           title: "title1",
           user_id: "test-user1",
@@ -576,7 +575,6 @@ describe("QiitaModule", () => {
           tags: ["laravel", "php"]
         },
         {
-          id: "2",
           article_id: "c0a2609ae61a72dcc60f",
           title: "title2",
           user_id: "test-user12",

--- a/tests/unit/Stock.spec.ts
+++ b/tests/unit/Stock.spec.ts
@@ -1,0 +1,51 @@
+import { shallowMount } from "@vue/test-utils";
+import Stock from "@/components/Stock.vue";
+import { IUncategorizedStock } from "@/domain/qiita";
+
+describe("Stock.vue", () => {
+  const stock: IUncategorizedStock = {
+    article_id: "c0a2609ae61a72dcc60f",
+    title: "title1",
+    user_id: "test-user1",
+    profile_image_url: "https://test.com/test/image",
+    article_created_at: "2018/09/30",
+    tags: ["laravel", "php"],
+    isChecked: true
+  };
+
+  const propsData: { stock: IUncategorizedStock; isCategorizing: boolean } = {
+    stock,
+    isCategorizing: false
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(Stock, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickCheckStock on onClickCheckStock()", () => {
+      const wrapper = shallowMount(Stock, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCheckStock();
+
+      expect(wrapper.emitted("clickCheckStock")).toBeTruthy();
+      expect(wrapper.emitted("clickCheckStock")[0][0]).toEqual(stock);
+    });
+  });
+
+  describe("template", () => {
+    it("should call onClickCheckStock when input is changed", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Stock, { propsData });
+
+      wrapper.setMethods({
+        onClickCheckStock: mock
+      });
+
+      wrapper.find("input").trigger("change");
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -50,12 +50,20 @@ describe("StockEdit.vue", () => {
     it("should emit clickSetIsCategorizing on changeCategory()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
+      const selectedCategoryId = 1;
 
       wrapper.setMethods({ doneEdit: mock });
 
       // @ts-ignore
+      wrapper.vm.selectedCategoryId = selectedCategoryId;
+
+      // @ts-ignore
       wrapper.vm.changeCategory();
       expect(mock).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
+        selectedCategoryId
+      );
     });
   });
 

--- a/tests/unit/StockList.spec.ts
+++ b/tests/unit/StockList.spec.ts
@@ -1,0 +1,72 @@
+import { shallowMount, mount, config } from "@vue/test-utils";
+import StockList from "@/components/StockList.vue";
+import Stock from "@/components/Stock.vue";
+import { IUncategorizedStock } from "@/domain/qiita";
+
+config.logModifiedComponents = false;
+
+describe("StockList.vue", () => {
+  const stocks: IUncategorizedStock[] = [
+    {
+      article_id: "c0a2609ae61a72dcc60f",
+      title: "title1",
+      user_id: "test-user1",
+      profile_image_url: "https://test.com/test/image",
+      article_created_at: "2018/09/30",
+      tags: ["laravel", "php"],
+      isChecked: true
+    },
+    {
+      article_id: "c0a2609ae61a72dcc60a",
+      title: "title2",
+      user_id: "test-user12",
+      profile_image_url: "https://test.com/test/image",
+      article_created_at: "2018/09/30",
+      tags: ["Vue.js", "Vuex", "TypeScript"],
+      isChecked: false
+    }
+  ];
+
+  const propsData: {
+    stocks: IUncategorizedStock[];
+    isCategorizing: boolean;
+  } = {
+    stocks,
+    isCategorizing: false
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(StockList, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickCheckStock on onClickCheckStock()", () => {
+      const wrapper = shallowMount(StockList, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCheckStock(stocks[0]);
+
+      expect(wrapper.emitted("clickCheckStock")).toBeTruthy();
+      expect(wrapper.emitted("clickCheckStock")[0][0]).toEqual(stocks[0]);
+    });
+  });
+
+  describe("template", () => {
+    it("should call clickUpdateCategory when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(StockList, { propsData });
+
+      wrapper.setMethods({
+        onClickCheckStock: mock
+      });
+
+      const stock = wrapper.find(Stock);
+
+      // @ts-ignore
+      stock.vm.onClickCheckStock();
+
+      expect(mock).toHaveBeenCalledWith(stocks[0]);
+    });
+  });
+});

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -40,7 +40,8 @@ describe("Stocks.vue", () => {
       updateCategory: jest.fn(),
       fetchCategory: jest.fn(),
       fetchStock: jest.fn(),
-      setIsCategorizing: jest.fn()
+      setIsCategorizing: jest.fn(),
+      categorize: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -117,6 +118,15 @@ describe("Stocks.vue", () => {
 
       expect(actions.setIsCategorizing).toHaveBeenCalled();
     });
+
+    it('calls store action "categorize" on onClickCategorize()', () => {
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.onClickCategorize();
+
+      expect(actions.categorize).toHaveBeenCalled();
+    });
   });
 
   // mountによる結合テスト
@@ -176,6 +186,25 @@ describe("Stocks.vue", () => {
       sideMenu.vm.changeCategory();
 
       expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onClickCategorize when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(Stocks, { store, localVue, router });
+
+      wrapper.setMethods({
+        onClickCategorize: mock
+      });
+
+      const stockEdit = wrapper.find(StockEdit);
+      const selectedCategoryId = 1;
+
+      // @ts-ignore
+      stockEdit.vm.selectedCategoryId = selectedCategoryId;
+      // @ts-ignore
+      stockEdit.vm.changeCategory();
+
+      expect(mock).toHaveBeenCalledWith(selectedCategoryId);
     });
   });
 });

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -1,12 +1,18 @@
 import { shallowMount, mount, createLocalVue, config } from "@vue/test-utils";
 import Vuex from "vuex";
-import { IUpdateCategoryPayload, QiitaModule } from "@/store/modules/qiita";
+import {
+  IUpdateCategoryPayload,
+  ICategorizePayload,
+  QiitaModule
+} from "@/store/modules/qiita";
 import Stocks from "@/pages/Stocks.vue";
 import SideMenu from "@/components/SideMenu.vue";
 import StockEdit from "@/components/StockEdit.vue";
+import StockList from "@/components/StockList.vue";
 import CategoryList from "@/components/CategoryList.vue";
 import { IQiitaState } from "@/types/qiita";
 import VueRouter from "vue-router";
+import { IUncategorizedStock } from "@/domain/qiita";
 
 config.logModifiedComponents = false;
 
@@ -41,7 +47,8 @@ describe("Stocks.vue", () => {
       fetchCategory: jest.fn(),
       fetchStock: jest.fn(),
       setIsCategorizing: jest.fn(),
-      categorize: jest.fn()
+      categorize: jest.fn(),
+      checkStock: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -123,9 +130,41 @@ describe("Stocks.vue", () => {
       const wrapper = shallowMount(Stocks, { store, localVue, router });
 
       // @ts-ignore
-      wrapper.vm.onClickCategorize();
+      wrapper.vm.onClickCategorize(1);
 
-      expect(actions.categorize).toHaveBeenCalled();
+      const categorizePayload: ICategorizePayload = {
+        categoryId: 1,
+        stockArticleIds: []
+      };
+
+      expect(actions.categorize).toHaveBeenCalledWith(
+        expect.anything(),
+        categorizePayload,
+        undefined
+      );
+    });
+
+    it('calls store action "checkStock" on onClickCheckStock()', () => {
+      const stock: IUncategorizedStock = {
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"],
+        isChecked: true
+      };
+
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.onClickCheckStock(stock);
+
+      expect(actions.checkStock).toHaveBeenCalledWith(
+        expect.anything(),
+        stock,
+        undefined
+      );
     });
   });
 
@@ -205,6 +244,31 @@ describe("Stocks.vue", () => {
       stockEdit.vm.changeCategory();
 
       expect(mock).toHaveBeenCalledWith(selectedCategoryId);
+    });
+
+    it("should call onClickCheckStock when checkBox is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(Stocks, { store, localVue, router });
+
+      wrapper.setMethods({
+        onClickCheckStock: mock
+      });
+
+      const stockList = wrapper.find(StockList);
+      const stock: IUncategorizedStock = {
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"],
+        isChecked: true
+      };
+
+      // @ts-ignore
+      stockList.vm.onClickCheckStock(stock);
+
+      expect(mock).toHaveBeenCalledWith(stock);
     });
   });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/128

# Doneの定義
- ストックのカテゴライズAPIとフロントエンドが通信できていること

# 変更点概要

## 仕様的変更点概要
指定されたカテゴリと選択されたストックをカテゴライズAPIのリクエストに指定し、送信する処理を作成。

## 技術的変更点概要
- 選択されたストックを取得するために、`State`の`stock`に選択されているかどうかを保持する`isChecked`を追加。
  -> ストック一覧のチェックボックスが押下されたタイミングで、更新している。

- カテゴライズAPIへのリクエスト処理を作成
  -> カテゴリ分類中の「保存」ボタン押下で、リクエストを行う

- Moduleとコンポーネントのテストケースを追加

# 補足情報
以下の処理については、別のPRにて対応する
- カテゴライズAPIにリクエスト後に、ストックの選択を解除する
- カテゴリが選択されずに「保存」ボタンが押下された場合のエラーメッセージ表示