### PR TITLE
バリデーションとリクエスト後の選択解除処理を作成

### DIFF
--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -2,7 +2,7 @@
   <div class="navbar-menu">
     <div class="navbar-end">
       <div v-if="isCategorizing">
-        <div class="select edit-header">
+        <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
           <select v-model="selectedCategoryId">
             <option
               v-for="category in categories"
@@ -39,8 +39,10 @@ export default class StockEdit extends Vue {
   categories!: ICategory[];
 
   selectedCategoryId: number = 0;
+  isValidationError: boolean = false;
 
   doneEdit() {
+    this.isValidationError = false;
     this.$emit("clickSetIsCategorizing");
   }
 
@@ -53,7 +55,11 @@ export default class StockEdit extends Vue {
   }
 
   changeCategory() {
-    // TODO カテゴリが選択されていなかった場合エラーを表示する
+    if (this.selectedCategoryId === 0) {
+      this.isValidationError = true;
+      return;
+    }
+
     this.$emit("clickCategorize", this.selectedCategoryId);
     this.doneEdit();
   }

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -166,6 +166,11 @@ const mutations: MutationTree<IQiitaState> = {
   },
   checkStock: (state, { stock, isChecked }) => {
     stock.isChecked = isChecked;
+  },
+  uncheckStock: state => {
+    state.stocks
+      .filter(stock => stock.isChecked)
+      .map(stock => (stock.isChecked = !stock.isChecked));
   }
 };
 
@@ -486,7 +491,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       };
 
       await categorize(categorizeRequest);
-      // TODO 選択されたストックを解除する
+      commit("uncheckStock");
     } catch (error) {
       router.push({
         name: "error",

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -5,7 +5,7 @@ import {
   IIssueLoginSessionResponse,
   IUncategorizedStock
 } from "@/domain/qiita";
-import { QiitaModule } from "@/store/modules/qiita";
+import {ICategorizePayload, QiitaModule} from "@/store/modules/qiita";
 import axios from "axios";
 import {
   IIssueAccessTokensResponse,
@@ -665,6 +665,38 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([["setIsCategorizing"]]);
+    });
+
+    it("should be able to uncheck Stock", async () => {
+      const categorizePayload: ICategorizePayload = {
+        categoryId: 1,
+        stockArticleIds: ["c0a2609ae61a72dcc60f","c0a2609ae61a72dcc60a"]
+      };
+
+      const commit = jest.fn();
+      const wrapper = (actions: any) => actions.categorize({ commit }, categorizePayload);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["uncheckStock"]]);
+    });
+
+    it("should be able to check Stock", async () => {
+      const stock: IUncategorizedStock =
+        {
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: true
+        };
+
+      const commit = jest.fn();
+      const wrapper = (actions: any) => actions.checkStock({ commit }, stock);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["checkStock", {stock, isChecked: !stock.isChecked}]]);
     });
   });
 });

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -5,7 +5,7 @@ import {
   IIssueLoginSessionResponse,
   IUncategorizedStock
 } from "@/domain/qiita";
-import {ICategorizePayload, QiitaModule} from "@/store/modules/qiita";
+import { ICategorizePayload, QiitaModule } from "@/store/modules/qiita";
 import axios from "axios";
 import {
   IIssueAccessTokensResponse,
@@ -670,33 +670,35 @@ describe("QiitaModule", () => {
     it("should be able to uncheck Stock", async () => {
       const categorizePayload: ICategorizePayload = {
         categoryId: 1,
-        stockArticleIds: ["c0a2609ae61a72dcc60f","c0a2609ae61a72dcc60a"]
+        stockArticleIds: ["c0a2609ae61a72dcc60f", "c0a2609ae61a72dcc60a"]
       };
 
       const commit = jest.fn();
-      const wrapper = (actions: any) => actions.categorize({ commit }, categorizePayload);
+      const wrapper = (actions: any) =>
+        actions.categorize({ commit }, categorizePayload);
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([["uncheckStock"]]);
     });
 
     it("should be able to check Stock", async () => {
-      const stock: IUncategorizedStock =
-        {
-          article_id: "c0a2609ae61a72dcc60f",
-          title: "title1",
-          user_id: "test-user1",
-          profile_image_url: "https://test.com/test/image",
-          article_created_at: "2018/09/30",
-          tags: ["laravel", "php"],
-          isChecked: true
-        };
+      const stock: IUncategorizedStock = {
+        article_id: "c0a2609ae61a72dcc60f",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"],
+        isChecked: true
+      };
 
       const commit = jest.fn();
       const wrapper = (actions: any) => actions.checkStock({ commit }, stock);
       await wrapper(QiitaModule.actions);
 
-      expect(commit.mock.calls).toEqual([["checkStock", {stock, isChecked: !stock.isChecked}]]);
+      expect(commit.mock.calls).toEqual([
+        ["checkStock", { stock, isChecked: !stock.isChecked }]
+      ]);
     });
   });
 });

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -25,7 +25,7 @@ describe("StockEdit.vue", () => {
       expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
     });
 
-    it("should emit clickSetIsCategorizing on startEdit()", () => {
+    it("should call doneEdit on startEdit()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
 
@@ -36,7 +36,7 @@ describe("StockEdit.vue", () => {
       expect(mock).toBeTruthy();
     });
 
-    it("should emit clickSetIsCategorizing on cancel()", () => {
+    it("should call doneEdit on cancel()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
 
@@ -47,7 +47,7 @@ describe("StockEdit.vue", () => {
       expect(mock).toBeTruthy();
     });
 
-    it("should emit clickSetIsCategorizing on changeCategory()", () => {
+    it("should emit clickCategorize on changeCategory()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
       const selectedCategoryId = 1;
@@ -64,6 +64,20 @@ describe("StockEdit.vue", () => {
       expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
         selectedCategoryId
       );
+    });
+
+    it("should not emit clickCategorize on changeCategory()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategoryId = 0;
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
     });
   });
 

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -219,10 +219,12 @@ describe("Stocks.vue", () => {
         onSetIsCategorizing: mock
       });
 
-      const sideMenu = wrapper.find(StockEdit);
+      const stockEdit = wrapper.find(StockEdit);
 
       // @ts-ignore
-      sideMenu.vm.changeCategory();
+      stockEdit.vm.selectedCategoryId = 1;
+      // @ts-ignore
+      stockEdit.vm.changeCategory();
 
       expect(mock).toHaveBeenCalled();
     });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/128

# Doneの定義
- カテゴリが選択されずに「保存」ボタンが押下された場合、エラーが表示されること
- カテゴライズAPIにリクエスト後に、ストックの選択が解除されていること

# スクリーンショット
カテゴリが選択されていなかった場合リストメニューを赤く表示
<img width="350" alt="2018-12-26 17 27 11" src="https://user-images.githubusercontent.com/32682645/50438957-891ef400-0933-11e9-97d9-99bee99bfef2.png">

# 変更点概要

## 仕様的変更点概要
カテゴリが選択されずに「保存」ボタンが押下された場合、エラーを表示し、カテゴライズAPIへのリクエストを行わないように修正。
カテゴライズAPIにリクエスト後に、ストックの選択を解除する処理を追加。

## 技術的変更点概要
`StockEdit`コンポーネントにバリデーション処理を追加。
ModuleのMutationにストックの選択状態を解除する`uncheckStock`を追加。
Moduleのテストケースに、Actionの`categorize`のテストケースが存在しなかったので合わせて追加。