### PR TITLE
ストック取得中のメッセージを表示する処理を追加

### DIFF
--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -1,0 +1,13 @@
+<template>
+  <div v-show="isLoading">ストック一覧を取得中...</div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class Loading extends Vue {
+  @Prop()
+  isLoading!: boolean;
+}
+</script>

--- a/src/components/StockList.vue
+++ b/src/components/StockList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-show="!isLoading">
     <div v-if="stocks.length">
       <Stock
         v-if="stocks.length"
@@ -30,6 +30,9 @@ export default class StockList extends Vue {
 
   @Prop()
   isCategorizing!: boolean;
+
+  @Prop()
+  isLoading!: boolean;
 
   onClickCheckStock(stock: IUncategorizedStock) {
     this.$emit("clickCheckStock", stock);

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -11,6 +11,7 @@
           />
         </div>
         <div class="column is-9">
+          <Loading :isLoading="isLoading" />
           <StockEdit
             v-show="stocks.length"
             :isCategorizing="isCategorizing"
@@ -21,6 +22,7 @@
           <StockList
             :stocks="stocks"
             :isCategorizing="isCategorizing"
+            :isLoading="isLoading"
             @clickCheckStock="onClickCheckStock"
           />
           <Pagination v-show="stocks.length" />
@@ -39,6 +41,7 @@ import SideMenu from "@/components/SideMenu.vue";
 import StockEdit from "@/components/StockEdit.vue";
 import StockList from "@/components/StockList.vue";
 import Pagination from "@/components/Pagination.vue";
+import Loading from "@/components/Loading.vue";
 import { ICategory, IUncategorizedStock } from "@/domain/qiita";
 import {
   IUpdateCategoryPayload,
@@ -54,7 +57,8 @@ const QiitaGetter = namespace("QiitaModule", Getter);
     SideMenu,
     StockEdit,
     StockList,
-    Pagination
+    Pagination,
+    Loading
   }
 })
 export default class Stocks extends Vue {
@@ -66,6 +70,9 @@ export default class Stocks extends Vue {
 
   @QiitaGetter
   isCategorizing!: boolean;
+
+  @QiitaGetter
+  isLoading!: boolean;
 
   @QiitaGetter
   checkedStockArticleIds!: string[];

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -95,7 +95,8 @@ const state: IQiitaState = {
   categories: [],
   stocks: [],
   paging: [],
-  isCategorizing: false
+  isCategorizing: false,
+  isLoading: true
 };
 
 const getters: GetterTree<IQiitaState, RootState> = {
@@ -119,6 +120,9 @@ const getters: GetterTree<IQiitaState, RootState> = {
   },
   isCategorizing: (state): IQiitaState["isCategorizing"] => {
     return state.isCategorizing;
+  },
+  isLoading: (state): IQiitaState["isLoading"] => {
+    return state.isLoading;
   },
   checkedStockArticleIds: (state): string[] => {
     return state.stocks
@@ -163,6 +167,9 @@ const mutations: MutationTree<IQiitaState> = {
   },
   setIsCategorizing: state => {
     state.isCategorizing = !state.isCategorizing;
+  },
+  setIsLoading: (state, isLoading: boolean) => {
+    state.isLoading = isLoading;
   },
   checkStock: (state, { stock, isChecked }) => {
     stock.isChecked = isChecked;
@@ -445,6 +452,8 @@ const actions: ActionTree<IQiitaState, RootState> = {
     page: IPage = { page: "1", perPage: "20", relation: "" }
   ) => {
     try {
+      commit("setIsLoading", true);
+
       const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
       const fetchStockRequest: IFetchStockRequest = {
         apiUrlBase: apiUrlBase(),
@@ -469,7 +478,9 @@ const actions: ActionTree<IQiitaState, RootState> = {
 
       commit("saveStocks", uncategorizedStocks);
       commit("savePaging", fetchStockResponse.paging);
+      commit("setIsLoading", false);
     } catch (error) {
+      commit("setIsLoading", false);
       router.push({
         name: "error",
         params: { errorMessage: error.response.data.message }

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -10,4 +10,5 @@ export interface IQiitaState {
   stocks: IUncategorizedStock[];
   paging: IPage[];
   isCategorizing: boolean;
+  isLoading: boolean;
 }

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -27,7 +27,8 @@ describe("AppHeader.vue", () => {
     categories: [],
     stocks: [],
     paging: [],
-    isCategorizing: false
+    isCategorizing: false,
+    isLoading: false
   };
 
   it("renders login", () => {

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -28,7 +28,8 @@ describe("Cancel.vue", () => {
       categories: [],
       stocks: [],
       paging: [],
-      isCategorizing: false
+      isCategorizing: false,
+      isLoading: false
     };
 
     actions = {

--- a/tests/unit/Loading.spec.ts
+++ b/tests/unit/Loading.spec.ts
@@ -1,0 +1,26 @@
+import { shallowMount } from "@vue/test-utils";
+import Loading from "@/components/Loading.vue";
+
+describe("Loading.vue", () => {
+  it("should have the correct props", () => {
+    const propsData = { isLoading: true };
+    const wrapper = shallowMount(Loading, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  it("renders loading", () => {
+    const propsData = { isLoading: true };
+    const wrapper = shallowMount(Loading, { propsData });
+
+    const loadingMessage = wrapper.find("div");
+    expect(loadingMessage.isVisible()).toBe(true);
+  });
+
+  it("do not renders loading", () => {
+    const propsData = { isLoading: false };
+    const wrapper = shallowMount(Loading, { propsData });
+
+    const loadingMessage = wrapper.find("div");
+    expect(loadingMessage.isVisible()).toBe(false);
+  });
+});

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -28,7 +28,8 @@ describe("Login.vue", () => {
       categories: [],
       stocks: [],
       paging: [],
-      isCategorizing: false
+      isCategorizing: false,
+      isLoading: false
     };
 
     actions = {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -55,7 +55,8 @@ describe("QiitaModule", () => {
         categories: [],
         stocks: stocks,
         paging: [],
-        isCategorizing: false
+        isCategorizing: false,
+        isLoading: false
       };
     });
 
@@ -139,7 +140,8 @@ describe("QiitaModule", () => {
         categories: [],
         stocks: [],
         paging: [],
-        isCategorizing: false
+        isCategorizing: false,
+        isLoading: false
       };
     });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -119,6 +119,13 @@ describe("QiitaModule", () => {
       expect(isCategorizing).toEqual(state.isCategorizing);
     });
 
+    it("should be able to get isLoading", () => {
+      const wrapper = (getters: any) => getters.isLoading(state);
+      const isLoading: IQiitaState["isLoading"] = wrapper(QiitaModule.getters);
+
+      expect(isLoading).toEqual(state.isLoading);
+    });
+
     it("should be able to get checkedStockArticleIds", () => {
       const wrapper = (getters: any) => getters.checkedStockArticleIds(state);
       const checkedStockArticleIds: string[] = wrapper(QiitaModule.getters);
@@ -307,6 +314,12 @@ describe("QiitaModule", () => {
       const wrapper = (mutations: any) => mutations.setIsCategorizing(state);
       wrapper(QiitaModule.mutations);
       expect(state.isCategorizing).toEqual(true);
+    });
+
+    it("should be able to save isLoading", () => {
+      const wrapper = (mutations: any) => mutations.setIsLoading(state, true);
+      wrapper(QiitaModule.mutations);
+      expect(state.isLoading).toEqual(true);
     });
 
     it("should be able to check Stock", () => {
@@ -656,8 +669,10 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
+        ["setIsLoading", true],
         ["saveStocks", stocks],
-        ["savePaging", paging]
+        ["savePaging", paging],
+        ["setIsLoading", false]
       ]);
     });
 

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -28,7 +28,8 @@ describe("SignUp.vue", () => {
       categories: [],
       stocks: [],
       paging: [],
-      isCategorizing: false
+      isCategorizing: false,
+      isLoading: false
     };
 
     actions = {

--- a/tests/unit/StockList.spec.ts
+++ b/tests/unit/StockList.spec.ts
@@ -30,9 +30,11 @@ describe("StockList.vue", () => {
   const propsData: {
     stocks: IUncategorizedStock[];
     isCategorizing: boolean;
+    isLoading: boolean;
   } = {
     stocks,
-    isCategorizing: false
+    isCategorizing: false,
+    isLoading: false
   };
 
   it("props", () => {
@@ -67,6 +69,21 @@ describe("StockList.vue", () => {
       stock.vm.onClickCheckStock();
 
       expect(mock).toHaveBeenCalledWith(stocks[0]);
+    });
+
+    it("renders list", () => {
+      const wrapper = shallowMount(StockList, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(true);
+    });
+
+    it("do not renders list", () => {
+      propsData.isLoading = true;
+      const wrapper = shallowMount(StockList, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(false);
     });
   });
 });

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -38,7 +38,8 @@ describe("Stocks.vue", () => {
       categories: [],
       stocks: [],
       paging: [],
-      isCategorizing: false
+      isCategorizing: false,
+      isLoading: false
     };
 
     actions = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/135

# Doneの定義
- ストック取得中にローディングメッセージが表示されること

# 変更点概要

## 仕様的変更点概要
ストックを取得中に、以下のメッセージを表示するように修正。
```
ストック一覧を取得中...
```

## 技術的変更点概要
Stateにローディング中かどうかを表すために`isLoading`を追加。
ローディングメッセージを表示するためのコンポーネント`Loading.vue`を作成。
Moduleとコンポーネントのテストケースを追加。