### PR TITLE
ページング処理を作成する

### DIFF
--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -70,7 +70,7 @@ import { IPage } from "@/domain/qiita";
 @Component
 export default class Pagination extends Vue {
   @Prop()
-  isLoading!: number;
+  isLoading!: boolean;
 
   @Prop()
   stocksLength!: number;

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="pagination" role="navigation" aria-label="pagination">
+  <nav v-show="stocksLength && !isLoading" class="pagination" role="navigation">
     <a
       class="pagination-previous"
       :disabled="!prevPage.page"
@@ -69,6 +69,12 @@ import { IPage } from "@/domain/qiita";
 
 @Component
 export default class Pagination extends Vue {
+  @Prop()
+  isLoading!: number;
+
+  @Prop()
+  stocksLength!: number;
+
   @Prop()
   currentPage!: number;
 

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -115,5 +115,6 @@ export default class Pagination extends Vue {
 <style scoped>
 .pagination {
   margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 </style>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,31 +1,109 @@
 <template>
   <nav class="pagination" role="navigation" aria-label="pagination">
-    <a class="pagination-previous">Previous</a>
-    <a class="pagination-next">Next page</a>
+    <a
+      class="pagination-previous"
+      :disabled="!prevPage.page"
+      @click="goToPage(prevPage);"
+      >Previous</a
+    >
+    <a
+      class="pagination-next"
+      :disabled="!nextPage.page"
+      @click="goToPage(nextPage);"
+      >Next page</a
+    >
+
     <ul class="pagination-list">
-      <li><a class="pagination-link" aria-label="Goto page 1">1</a></li>
-      <li><span class="pagination-ellipsis">&hellip;</span></li>
-      <li><a class="pagination-link" aria-label="Goto page 45">45</a></li>
       <li>
         <a
-          class="pagination-link is-current"
-          aria-label="Page 46"
-          aria-current="page"
-          >46</a
+          class="pagination-link"
+          v-show="showFirstEllipsis()"
+          @click="goToPage(firstPage);"
+          >{{ firstPage.page }}</a
         >
       </li>
-      <li><a class="pagination-link" aria-label="Goto page 47">47</a></li>
-      <li><span class="pagination-ellipsis">&hellip;</span></li>
-      <li><a class="pagination-link" aria-label="Goto page 86">86</a></li>
+      <li>
+        <span class="pagination-ellipsis" v-show="showPrevEllipsis()"
+          >&hellip;</span
+        >
+      </li>
+      <li>
+        <a
+          class="pagination-link"
+          v-show="prevPage.page"
+          @click="goToPage(prevPage);"
+          >{{ prevPage.page }}</a
+        >
+      </li>
+      <li>
+        <a class="pagination-link is-current">{{ currentPage }}</a>
+      </li>
+      <li>
+        <a
+          class="pagination-link"
+          v-show="nextPage.page"
+          @click="goToPage(nextPage);"
+          >{{ nextPage.page }}</a
+        >
+      </li>
+      <li>
+        <span class="pagination-ellipsis" v-show="showNestEllipsis()"
+          >&hellip;</span
+        >
+      </li>
+      <li>
+        <a
+          class="pagination-link"
+          v-show="showLastPage()"
+          @click="goToPage(lastPage);"
+          >{{ lastPage.page }}</a
+        >
+      </li>
     </ul>
   </nav>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { IPage } from "@/domain/qiita";
 
 @Component
-export default class Pagination extends Vue {}
+export default class Pagination extends Vue {
+  @Prop()
+  currentPage!: number;
+
+  @Prop()
+  firstPage!: { page: number; perPage: number; relation: string };
+
+  @Prop()
+  prevPage!: { page: number; perPage: number; relation: string };
+
+  @Prop()
+  nextPage!: { page: number; perPage: number; relation: string };
+
+  @Prop()
+  lastPage!: { page: number; perPage: number; relation: string };
+
+  showFirstEllipsis() {
+    return this.firstPage.page !== this.prevPage.page;
+  }
+
+  showPrevEllipsis() {
+    return this.firstPage.page + 1 < this.prevPage.page;
+  }
+
+  showNestEllipsis() {
+    return this.nextPage.page + 1 < this.lastPage.page;
+  }
+
+  showLastPage() {
+    return this.nextPage.page < this.lastPage.page;
+  }
+
+  goToPage(page: IPage) {
+    this.$emit("clickGoToPage", page);
+  }
+}
 </script>
 
 <style scoped>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="navbar-menu">
+  <div v-show="stocksLength && !isLoading" class="navbar-menu">
     <div class="navbar-end">
       <div v-if="isCategorizing">
         <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
@@ -32,6 +32,12 @@ import { ICategory } from "@/domain/qiita";
 
 @Component
 export default class StockEdit extends Vue {
+  @Prop()
+  isLoading!: number;
+
+  @Prop()
+  stocksLength!: number;
+
   @Prop()
   isCategorizing!: boolean;
 

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -33,7 +33,7 @@ import { ICategory } from "@/domain/qiita";
 @Component
 export default class StockEdit extends Vue {
   @Prop()
-  isLoading!: number;
+  isLoading!: boolean;
 
   @Prop()
   stocksLength!: number;

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -141,8 +141,8 @@ interface IQiitaStockerErrorData {
 export interface IFetchStockRequest {
   apiUrlBase: string;
   sessionId: string;
-  page: string;
-  parPage: string;
+  page: number;
+  parPage: number;
 }
 
 export interface ICategorizeRequest {
@@ -153,8 +153,8 @@ export interface ICategorizeRequest {
 }
 
 export interface IPage {
-  page: string;
-  perPage: string;
+  page: number;
+  perPage: number;
   relation: string;
 }
 

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -222,9 +222,12 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
           /page=(.*?)&per_page=(.*?)>; rel="(\w+)"/
         );
 
+        const castPage: number = parseInt(page);
+        const castPerPage: number = parseInt(perPage);
+
         return {
-          page,
-          perPage,
+          page: castPage,
+          perPage: castPerPage,
           relation
         };
       });

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -13,7 +13,8 @@
         <div class="column is-9">
           <Loading :isLoading="isLoading" />
           <StockEdit
-            v-show="stocks.length"
+            :isLoading="isLoading"
+            :stocksLength="stocks.length"
             :isCategorizing="isCategorizing"
             :categories="categories"
             @clickSetIsCategorizing="onSetIsCategorizing"
@@ -26,7 +27,8 @@
             @clickCheckStock="onClickCheckStock"
           />
           <Pagination
-            v-show="stocks.length"
+            :isLoading="isLoading"
+            :stocksLength="stocks.length"
             :currentPage="currentPage"
             :firstPage="firstPage"
             :prevPage="prevPage"

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -25,7 +25,15 @@
             :isLoading="isLoading"
             @clickCheckStock="onClickCheckStock"
           />
-          <Pagination v-show="stocks.length" />
+          <Pagination
+            v-show="stocks.length"
+            :currentPage="currentPage"
+            :firstPage="firstPage"
+            :prevPage="prevPage"
+            :nextPage="nextPage"
+            :lastPage="lastPage"
+            @clickGoToPage="fetchOtherPageStock"
+          />
         </div>
       </div>
     </main>
@@ -42,7 +50,7 @@ import StockEdit from "@/components/StockEdit.vue";
 import StockList from "@/components/StockList.vue";
 import Pagination from "@/components/Pagination.vue";
 import Loading from "@/components/Loading.vue";
-import { ICategory, IUncategorizedStock } from "@/domain/qiita";
+import { ICategory, IUncategorizedStock, IPage } from "@/domain/qiita";
 import {
   IUpdateCategoryPayload,
   ICategorizePayload
@@ -77,6 +85,21 @@ export default class Stocks extends Vue {
   @QiitaGetter
   checkedStockArticleIds!: string[];
 
+  @QiitaGetter
+  currentPage!: number;
+
+  @QiitaGetter
+  firstPage!: IPage;
+
+  @QiitaGetter
+  prevPage!: IPage;
+
+  @QiitaGetter
+  nextPage!: IPage;
+
+  @QiitaGetter
+  lastPage!: IPage;
+
   @QiitaAction
   saveCategory!: (category: string) => void;
 
@@ -87,7 +110,7 @@ export default class Stocks extends Vue {
   updateCategory!: (updateCategoryPayload: IUpdateCategoryPayload) => void;
 
   @QiitaAction
-  fetchStock!: () => void;
+  fetchStock!: (page?: IPage) => void;
 
   @QiitaAction
   setIsCategorizing!: () => void;
@@ -116,6 +139,10 @@ export default class Stocks extends Vue {
 
   onClickCheckStock(stock: IUncategorizedStock) {
     this.checkStock(stock);
+  }
+
+  fetchOtherPageStock(page: IPage) {
+    this.fetchStock(page);
   }
 
   created() {

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -8,6 +8,7 @@ export interface IQiitaState {
   sessionId: string;
   categories: ICategory[];
   stocks: IUncategorizedStock[];
+  currentPage: number;
   paging: IPage[];
   isCategorizing: boolean;
   isLoading: boolean;

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -26,6 +26,7 @@ describe("AppHeader.vue", () => {
     sessionId: "",
     categories: [],
     stocks: [],
+    currentPage: 1,
     paging: [],
     isCategorizing: false,
     isLoading: false

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -27,6 +27,7 @@ describe("Cancel.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
+      currentPage: 1,
       paging: [],
       isCategorizing: false,
       isLoading: false

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -27,6 +27,7 @@ describe("Login.vue", () => {
       sessionId: "",
       categories: [],
       stocks: [],
+      currentPage: 1,
       paging: [],
       isCategorizing: false,
       isLoading: false

--- a/tests/unit/Pagination.spec.ts
+++ b/tests/unit/Pagination.spec.ts
@@ -1,0 +1,177 @@
+import { shallowMount } from "@vue/test-utils";
+import Pagination from "@/components/Pagination.vue";
+import { IPage } from "@/domain/qiita";
+
+describe("Pagination.vue", () => {
+  const firstPage: IPage = {
+    page: 1,
+    perPage: 20,
+    relation: "first"
+  };
+  const prevPage: IPage = {
+    page: 2,
+    perPage: 20,
+    relation: "prev"
+  };
+  const nextPage: IPage = {
+    page: 4,
+    perPage: 20,
+    relation: "next"
+  };
+  const lastPage: IPage = {
+    page: 5,
+    perPage: 20,
+    relation: "last"
+  };
+
+  const propsData: {
+    isLoading: boolean;
+    stocksLength: number;
+    currentPage: number;
+    firstPage: IPage;
+    prevPage: IPage;
+    nextPage: IPage;
+    lastPage: IPage;
+  } = {
+    isLoading: false,
+    stocksLength: 20,
+    currentPage: 3,
+    firstPage,
+    prevPage,
+    nextPage,
+    lastPage
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(Pagination, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickGoToPage on goToPage()", () => {
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.goToPage(firstPage);
+      expect(wrapper.emitted("clickGoToPage")).toBeTruthy();
+      expect(wrapper.emitted("clickGoToPage")[0][0]).toEqual(firstPage);
+    });
+  });
+
+  describe("template", () => {
+    it("should call startEdit when previous is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const previous = wrapper.findAll("a").at(0);
+      previous.trigger("click");
+      expect(previous.classes()).toContain("pagination-previous");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(prevPage);
+    });
+
+    it("should call startEdit when next is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const next = wrapper.findAll("a").at(1);
+      next.trigger("click");
+      expect(next.classes()).toContain("pagination-next");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(nextPage);
+    });
+
+    it("should call startEdit when first is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const first = wrapper.findAll("a").at(2);
+      first.trigger("click");
+      expect(first.classes()).toContain("pagination-link");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(firstPage);
+    });
+
+    it("should call startEdit when prev is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const prev = wrapper.findAll("a").at(3);
+      prev.trigger("click");
+      expect(prev.classes()).toContain("pagination-link");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(prevPage);
+    });
+
+    it("should call startEdit when next is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const next = wrapper.findAll("a").at(5);
+      next.trigger("click");
+      expect(next.classes()).toContain("pagination-link");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(nextPage);
+    });
+
+    it("should call startEdit when last is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      wrapper.setMethods({
+        goToPage: mock
+      });
+
+      const last = wrapper.findAll("a").at(6);
+      last.trigger("click");
+      expect(last.classes()).toContain("pagination-link");
+      expect(mock).toHaveBeenCalled();
+      expect(mock).toHaveBeenCalledWith(lastPage);
+    });
+
+    it("renders pagination", () => {
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      const loadingMessage = wrapper.find("nav");
+      expect(loadingMessage.isVisible()).toBe(true);
+    });
+
+    it("do not renders pagination when loading", () => {
+      propsData.isLoading = true;
+      propsData.stocksLength = 20;
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      const loadingMessage = wrapper.find("nav");
+      expect(loadingMessage.isVisible()).toBe(false);
+    });
+
+    it("do not renders pagination when stocks length is 0", () => {
+      propsData.isLoading = false;
+      propsData.stocksLength = 0;
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      const loadingMessage = wrapper.find("nav");
+      expect(loadingMessage.isVisible()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -54,6 +54,7 @@ describe("QiitaModule", () => {
         sessionId: "",
         categories: [],
         stocks: stocks,
+        currentPage: 1,
         paging: [],
         isCategorizing: false,
         isLoading: false
@@ -146,6 +147,7 @@ describe("QiitaModule", () => {
         sessionId: "",
         categories: [],
         stocks: [],
+        currentPage: 1,
         paging: [],
         isCategorizing: false,
         isLoading: false
@@ -283,23 +285,23 @@ describe("QiitaModule", () => {
     it("should be able to save paging", () => {
       const paging: IPage[] = [
         {
-          page: "4",
-          perPage: "20",
+          page: 4,
+          perPage: 20,
           relation: "next"
         },
         {
-          page: "5",
-          perPage: "20",
+          page: 5,
+          perPage: 20,
           relation: "last"
         },
         {
-          page: "1",
-          perPage: "20",
+          page: 1,
+          perPage: 20,
           relation: "first"
         },
         {
-          page: "2",
-          perPage: "20",
+          page: 2,
+          perPage: 20,
           relation: "prev"
         }
       ];
@@ -626,23 +628,23 @@ describe("QiitaModule", () => {
 
       const paging: IPage[] = [
         {
-          page: "4",
-          perPage: "20",
+          page: 4,
+          perPage: 20,
           relation: "next"
         },
         {
-          page: "5",
-          perPage: "20",
+          page: 5,
+          perPage: 20,
           relation: "last"
         },
         {
-          page: "1",
-          perPage: "20",
+          page: 1,
+          perPage: 20,
           relation: "first"
         },
         {
-          page: "2",
-          perPage: "20",
+          page: 2,
+          perPage: 0,
           relation: "prev"
         }
       ];

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -44,6 +44,26 @@ describe("QiitaModule", () => {
         isChecked: false
       }
     ];
+    const firstPage: IPage = {
+      page: 1,
+      perPage: 20,
+      relation: "first"
+    };
+    const prevPage: IPage = {
+      page: 2,
+      perPage: 20,
+      relation: "prev"
+    };
+    const nextPage: IPage = {
+      page: 3,
+      perPage: 20,
+      relation: "next"
+    };
+    const lastPage: IPage = {
+      page: 5,
+      perPage: 20,
+      relation: "last"
+    };
 
     beforeEach(() => {
       state = {
@@ -55,7 +75,7 @@ describe("QiitaModule", () => {
         categories: [],
         stocks: stocks,
         currentPage: 1,
-        paging: [],
+        paging: [firstPage, prevPage, nextPage, lastPage],
         isCategorizing: false,
         isLoading: false
       };
@@ -132,6 +152,43 @@ describe("QiitaModule", () => {
       const checkedStockArticleIds: string[] = wrapper(QiitaModule.getters);
 
       expect(checkedStockArticleIds).toEqual([state.stocks[0].article_id]);
+    });
+
+    it("should be able to get currentPage", () => {
+      const wrapper = (getters: any) => getters.currentPage(state);
+      const currentPage: IQiitaState["currentPage"] = wrapper(
+        QiitaModule.getters
+      );
+
+      expect(currentPage).toEqual(state.currentPage);
+    });
+
+    it("should be able to get firstPage", () => {
+      const wrapper = (getters: any) => getters.firstPage(state);
+      const expectedPage: IPage = wrapper(QiitaModule.getters);
+
+      expect(expectedPage).toEqual(firstPage);
+    });
+
+    it("should be able to get prevPage", () => {
+      const wrapper = (getters: any) => getters.prevPage(state);
+      const expectedPage: IPage = wrapper(QiitaModule.getters);
+
+      expect(expectedPage).toEqual(prevPage);
+    });
+
+    it("should be able to get nextPage", () => {
+      const wrapper = (getters: any) => getters.nextPage(state);
+      const expectedPage: IPage = wrapper(QiitaModule.getters);
+
+      expect(expectedPage).toEqual(nextPage);
+    });
+
+    it("should be able to get lastPage", () => {
+      const wrapper = (getters: any) => getters.lastPage(state);
+      const expectedPage: IPage = wrapper(QiitaModule.getters);
+
+      expect(expectedPage).toEqual(lastPage);
     });
   });
 
@@ -310,6 +367,12 @@ describe("QiitaModule", () => {
       wrapper(QiitaModule.mutations);
 
       expect(state.paging).toEqual(paging);
+    });
+
+    it("should be able to save currentPage", () => {
+      const wrapper = (mutations: any) => mutations.saveCurrentPage(state, 2);
+      wrapper(QiitaModule.mutations);
+      expect(state.currentPage).toEqual(2);
     });
 
     it("should be able to save isCategorizing", () => {
@@ -644,7 +707,7 @@ describe("QiitaModule", () => {
         },
         {
           page: 2,
-          perPage: 0,
+          perPage: 20,
           relation: "prev"
         }
       ];
@@ -674,6 +737,7 @@ describe("QiitaModule", () => {
         ["setIsLoading", true],
         ["saveStocks", stocks],
         ["savePaging", paging],
+        ["saveCurrentPage", 1],
         ["setIsLoading", false]
       ]);
     });

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -27,6 +27,7 @@ describe("SignUp.vue", () => {
       sessionId: "-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
+      currentPage: 1,
       paging: [],
       isCategorizing: false,
       isLoading: false

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -3,7 +3,14 @@ import StockEdit from "@/components/StockEdit.vue";
 import { ICategory } from "@/domain/qiita";
 
 describe("StockEdit.vue", () => {
-  const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
+  const propsData: {
+    isLoading: boolean;
+    stocksLength: number;
+    isCategorizing: boolean;
+    categories: ICategory[];
+  } = {
+    isLoading: false,
+    stocksLength: 10,
     isCategorizing: false,
     categories: [
       { categoryId: 1, name: "テストカテゴリ1" },
@@ -95,14 +102,11 @@ describe("StockEdit.vue", () => {
     });
 
     it("should call changeCategory when button is clicked", () => {
-      const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
-        isCategorizing: true,
-        categories: [
-          { categoryId: 1, name: "テストカテゴリ1" },
-          { categoryId: 2, name: "テストカテゴリ2" }
-        ]
-      };
-
+      propsData.isCategorizing = true;
+      propsData.categories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
 
@@ -118,13 +122,11 @@ describe("StockEdit.vue", () => {
     });
 
     it("should call cancel when button is clicked", () => {
-      const propsData: { isCategorizing: boolean; categories: ICategory[] } = {
-        isCategorizing: true,
-        categories: [
-          { categoryId: 1, name: "テストカテゴリ1" },
-          { categoryId: 2, name: "テストカテゴリ2" }
-        ]
-      };
+      propsData.isCategorizing = true;
+      propsData.categories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
 
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
@@ -138,6 +140,31 @@ describe("StockEdit.vue", () => {
         .at(1)
         .trigger("click");
       expect(mock).toHaveBeenCalled();
+    });
+
+    it("renders navbar", () => {
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(true);
+    });
+
+    it("do not renders navbar when loading", () => {
+      propsData.isLoading = true;
+      propsData.stocksLength = 20;
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(false);
+    });
+
+    it("do not renders navbar when stocks length is 0", () => {
+      propsData.isLoading = false;
+      propsData.stocksLength = 0;
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(false);
     });
   });
 });

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -37,6 +37,7 @@ describe("Stocks.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
+      currentPage: 1,
       paging: [],
       isCategorizing: false,
       isLoading: false

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -10,9 +10,10 @@ import SideMenu from "@/components/SideMenu.vue";
 import StockEdit from "@/components/StockEdit.vue";
 import StockList from "@/components/StockList.vue";
 import CategoryList from "@/components/CategoryList.vue";
+import Pagination from "@/components/Pagination.vue";
 import { IQiitaState } from "@/types/qiita";
 import VueRouter from "vue-router";
-import { IUncategorizedStock } from "@/domain/qiita";
+import {IPage, IUncategorizedStock} from "@/domain/qiita";
 
 config.logModifiedComponents = false;
 
@@ -168,6 +169,25 @@ describe("Stocks.vue", () => {
         undefined
       );
     });
+
+    it('calls store action "fetchStock" on fetchOtherPageStock()', () => {
+      const page: IPage = {
+        page: 4,
+        perPage: 20,
+        relation: "next"
+      };
+
+      const wrapper = shallowMount(Stocks, { store, localVue, router });
+
+      // @ts-ignore
+      wrapper.vm.fetchOtherPageStock(page);
+
+      expect(actions.fetchStock).toHaveBeenCalledWith(
+        expect.anything(),
+        page,
+        undefined
+      );
+    });
   });
 
   // mountによる結合テスト
@@ -273,6 +293,27 @@ describe("Stocks.vue", () => {
       stockList.vm.onClickCheckStock(stock);
 
       expect(mock).toHaveBeenCalledWith(stock);
+    });
+
+    it("should call fetchOtherPageStock when pagination is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(Stocks, { store, localVue, router });
+
+      wrapper.setMethods({
+        fetchOtherPageStock: mock
+      });
+
+      const pagination = wrapper.find(Pagination);
+      const page: IPage = {
+        page: 4,
+        perPage: 20,
+        relation: "next"
+      };
+
+      // @ts-ignore
+      pagination.vm.goToPage(page);
+
+      expect(mock).toHaveBeenCalledWith(page);
     });
   });
 });

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -13,7 +13,7 @@ import CategoryList from "@/components/CategoryList.vue";
 import Pagination from "@/components/Pagination.vue";
 import { IQiitaState } from "@/types/qiita";
 import VueRouter from "vue-router";
-import {IPage, IUncategorizedStock} from "@/domain/qiita";
+import { IPage, IUncategorizedStock } from "@/domain/qiita";
 
 config.logModifiedComponents = false;
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/137

# Doneの定義
- ストック一覧の画面でページング処理が作成されていること

# スクリーンショット
<img width="946" alt="2018-12-28 22 07 49" src="https://user-images.githubusercontent.com/32682645/50516240-10639780-0aed-11e9-82d2-e43359ca7c6d.png">

# 変更点概要

## 仕様的変更点概要
ストック一覧のページング処理を作成。
ページを押下することで、次ページのストックを取得するAPIへのリクエストを行う。

## 技術的変更点概要
Stateに現在表示しているページを保持する`currentPage`を追加。
`Pagination.vue`コンポーネントに、ページの表示処理とストック取得APIへのリクエスト処理を追加。