### PR TITLE
fontawesomeの導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "vue-cli-service test:e2e"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.6.3",
     "axios": "^0.18.0",
     "bulma": "^0.7.2",
     "uuid": "^3.3.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,13 @@
   <div id="app"><router-view /></div>
 </template>
 
+<script lang="ts">
+import "@fortawesome/fontawesome-free/js/all.js";
+import { Component, Vue } from "vue-property-decorator";
+@Component
+export default class App extends Vue {}
+</script>
+
 <style lang="scss">
 @import "../node_modules/bulma/bulma.sass";
 </style>

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -7,7 +7,10 @@
         :class="`${isSelecting && 'is-active'}`"
       >
         {{ category.name }}
-        <p class="edit" @click="editing = true;">編集</p>
+
+        <p class="edit" @click="editing = true;">
+          <span class="icon"> <i class="fas fa-pencil-alt fa-lg"></i> </span>
+        </p>
       </a>
     </div>
     <div v-show="editing">
@@ -21,8 +24,9 @@
         <a
           class="has-text-grey is-size-7 destroy"
           @click="onClickDestroyCategory"
-          >削除</a
         >
+          <span class="icon"> <i class="far fa-trash-alt fa-2x"></i> </span>
+        </a>
         <p v-if="isValidationError" class="help is-danger">
           カテゴリを入力してください。
         </p>

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -14,9 +14,9 @@
       </a>
     </div>
     <div v-show="editing">
-      <div class="field">
+      <div class="edit-field">
         <input
-          :class="`input edit-field ${isValidationError && 'is-danger'}`"
+          :class="`input input-field ${isValidationError && 'is-danger'}`"
           type="text"
           v-focus="editing"
           v-model="editCategoryName"
@@ -31,7 +31,7 @@
           カテゴリを入力してください。
         </p>
       </div>
-      <div class="field">
+      <div class="edit-field">
         <p class="control">
           <button
             class="button is-small is-danger"
@@ -151,6 +151,10 @@ li:hover .edit {
 }
 
 .edit-field {
+  margin-bottom: 0.3rem;
+}
+
+.input-field {
   width: auto;
 }
 

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -46,5 +46,6 @@ export default class CategoryList extends Vue {
 <style scoped>
 .side-menu-list {
   margin-top: 1em;
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -26,20 +26,17 @@
         <div class="container">
           <h1 class="title has-text-centered">What can?</h1>
           <div class="columns">
-            <div class="column is-4 has-text-centered">
-              <img src="../assets/logo.png" width="70" height="70" />
-              <h2 class="title is-size-5">ストックの取得</h2>
+            <div class="column is-6 has-text-centered">
+              <span class="icon">
+                <i class="fas fa-folder-open fa-4x"></i>
+              </span>
+              <h2 class="title is-size-5 detail-title">ストックの取得</h2>
               <p>ストックした記事の一覧を取得</p>
             </div>
-            <div class="column is-4 has-text-centered">
-              <img src="../assets/logo.png" width="70" height="70" />
-              <h2 class="title is-size-5">カテゴリの作成</h2>
+            <div class="column is-6 has-text-centered">
+              <span class="icon"> <i class="fas fa-list fa-4x"></i> </span>
+              <h2 class="title is-size-5 detail-title">カテゴリの作成</h2>
               <p>カテゴライズすることで、記事を整理可能に</p>
-            </div>
-            <div class="column is-4 has-text-centered">
-              <img src="../assets/logo.png" width="70" height="70" />
-              <h2 class="title is-size-5">検索機能</h2>
-              <p>ストック内を検索して、記事に素早くアクセス</p>
             </div>
           </div>
         </div>
@@ -69,5 +66,9 @@ export default class Home extends Vue {}
 }
 .subtitle {
   padding-top: 1rem;
+}
+
+.detail-title {
+  padding-top: 1.5rem;
 }
 </style>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -69,6 +69,6 @@ export default class Home extends Vue {}
 }
 
 .detail-title {
-  padding-top: 1.5rem;
+  padding-top: 0.75rem;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,6 +800,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@fortawesome/fontawesome-free@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.6.3.tgz#61c122c420d7a91613f393d6a06e5a4c6ae6abf3"
+  integrity sha512-s5PLdI9NYgjBvfrv6rhirPHlAHWx+Sfo/IjsAeiXYfmemC/GSjwsyz1wLnGPazbLPXWfk62ks980o9AmsxYUEQ==
+
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz#be7c7846128b88f6a9b1d1261a0ad06eb5c0fdf8"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/118

# Doneの定義
- fontawesomeが導入されていること

# スクリーンショット
- トップページ
<img width="1008" alt="2019-01-02 17 50 38" src="https://user-images.githubusercontent.com/32682645/50585151-fa702100-0eb6-11e9-8c7a-205007354a32.png">

- カテゴリ一覧
<img width="318" alt="2019-01-02 17 51 28" src="https://user-images.githubusercontent.com/32682645/50585168-1247a500-0eb7-11e9-9dd6-65959b49b339.png">

<img width="318" alt="2019-01-02 17 51 58" src="https://user-images.githubusercontent.com/32682645/50585183-212e5780-0eb7-11e9-9120-fb70dc136bab.png">

# 変更点概要

## 仕様的変更点概要
トップページとカテゴリ一覧にアイコンを表示。

## 技術的変更点概要
`@fortawesome/fontawesome-free`パッケージを追加。
トップページとカテゴリ一覧にアイコンを表示し、CSSを調整。