### PR TITLE
スマホサイトのレイアウト修正

### DIFF
--- a/src/components/Stock.vue
+++ b/src/components/Stock.vue
@@ -5,7 +5,7 @@
         <img :src="stock.profile_image_url" />
       </a>
     </figure>
-    <div class="media-content">
+    <div class="media-content content-no-scroll">
       <div class="content">
         <div class="item-info">
           <p>
@@ -81,5 +81,9 @@ a:hover {
 .item-title {
   margin-bottom: 0.3em;
   font-size: 1.4em;
+}
+
+.content-no-scroll {
+  overflow-x: visible;
 }
 </style>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="stocksLength && !isLoading" class="navbar-menu">
+  <div v-show="stocksLength && !isLoading" class="navbar-menu edit-menu">
     <div class="navbar-end">
       <div v-if="isCategorizing">
         <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
@@ -75,5 +75,10 @@ export default class StockEdit extends Vue {
 <style scoped>
 .edit-header {
   margin-right: 10px;
+}
+
+.edit-menu {
+  display: block;
+  box-shadow: none;
 }
 </style>

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -3,7 +3,7 @@
     <AppHeader />
     <main class="container">
       <div class="columns">
-        <div class="column is-3">
+        <div class="column is-3 column-padding">
           <SideMenu
             :categories="categories"
             @clickSaveCategory="onClickSaveCategory"
@@ -12,7 +12,7 @@
             @clickDestroyCategory="onClickDestroyCategory"
           />
         </div>
-        <div class="column is-9">
+        <div class="column is-9 column-padding">
           <Loading :isLoading="isLoading" />
           <StockEdit
             :isLoading="isLoading"
@@ -211,5 +211,9 @@ export default class StockCategories extends Vue {
 <style scoped>
 .container {
   padding-top: 2rem;
+}
+
+.column-padding {
+  padding-left: 1.25rem;
 }
 </style>

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -3,7 +3,7 @@
     <AppHeader />
     <main class="container">
       <div class="columns">
-        <div class="column is-3">
+        <div class="column is-3 column-padding">
           <SideMenu
             :categories="categories"
             @clickSaveCategory="onClickSaveCategory"
@@ -11,7 +11,7 @@
             @clickDestroyCategory="onClickDestroyCategory"
           />
         </div>
-        <div class="column is-9">
+        <div class="column is-9 column-padding">
           <Loading :isLoading="isLoading" />
           <StockEdit
             :isLoading="isLoading"
@@ -179,5 +179,8 @@ export default class Stocks extends Vue {
 <style scoped>
 .container {
   padding-top: 2rem;
+}
+.column-padding {
+  padding-left: 1.25rem;
 }
 </style>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/116

# Doneの定義
- スマホ画面のレイアウトに適切なCSSが当てられていること

# スクリーンショット
<img width="378" alt="2019-01-03 0 52 59" src="https://user-images.githubusercontent.com/32682645/50599713-35dc1100-0ef2-11e9-812b-0cc624df5280.png">

# 変更点概要

## 仕様的変更点概要
以下の修正を行なった。
- ストック一覧画面で画面の余白を表示
- ストックのスクロールが表示されないように修正
- 「カテゴリを分類する」ボタンがレスポンシブ対応されていなかったので、常に表示されるように修正

## 技術的変更点概要
コンポーネントのスタイルを修正
