### PR TITLE
サイドメニューの修正

### DIFF
--- a/src/components/DefaultMenuList.vue
+++ b/src/components/DefaultMenuList.vue
@@ -2,7 +2,7 @@
   <section>
     <ul class="menu-list">
       <li>
-        <a :class="`${isSelecting && 'is-active'}`" @click="handleClick">
+        <a :class="`${isSelecting() && 'is-active'}`" @click="handleClick">
           全てのストック
         </a>
       </li>
@@ -11,16 +11,22 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Prop } from "vue-property-decorator";
 
 @Component
 export default class DefaultMenuList extends Vue {
-  isSelecting: boolean = false;
+  @Prop()
+  displayCategoryId!: number;
 
   handleClick() {
+    this.$emit("clickStocksAll");
     this.$router.push({
       name: "stocks"
     });
+  }
+
+  isSelecting() {
+    return this.displayCategoryId === 0;
   }
 }
 </script>

--- a/src/components/DefaultMenuList.vue
+++ b/src/components/DefaultMenuList.vue
@@ -1,8 +1,11 @@
 <template>
   <section>
     <ul class="menu-list">
-      <li><a class="is-active">全てのストック</a></li>
-      <li><a>未分類</a></li>
+      <li>
+        <a :class="`${isSelecting && 'is-active'}`" @click="handleClick">
+          全てのストック
+        </a>
+      </li>
     </ul>
   </section>
 </template>
@@ -11,5 +14,13 @@
 import { Component, Vue } from "vue-property-decorator";
 
 @Component
-export default class DefaultMenuList extends Vue {}
+export default class DefaultMenuList extends Vue {
+  isSelecting: boolean = false;
+
+  handleClick() {
+    this.$router.push({
+      name: "stocks"
+    });
+  }
+}
 </script>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,6 +1,9 @@
 <template>
   <aside class="submenu menu">
-    <DefaultMenuList />
+    <DefaultMenuList
+      :displayCategoryId="displayCategoryId"
+      @clickStocksAll="onClickStocksAll"
+    />
     <CategoryList
       :categories="categories"
       @clickUpdateCategory="onClickUpdateCategory"
@@ -30,6 +33,9 @@ export default class SideMenu extends Vue {
   @Prop()
   categories!: ICategory[];
 
+  @Prop()
+  displayCategoryId!: number;
+
   onClickCategory() {
     this.$emit("clickCategory");
   }
@@ -44,6 +50,10 @@ export default class SideMenu extends Vue {
 
   onClickDestroyCategory(categoryId: number) {
     this.$emit("clickDestroyCategory", categoryId);
+  }
+
+  onClickStocksAll() {
+    this.$emit("clickStocksAll");
   }
 }
 </script>

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -6,10 +6,12 @@
         <div class="column is-3 column-padding">
           <SideMenu
             :categories="categories"
+            :displayCategoryId="displayCategoryId"
             @clickSaveCategory="onClickSaveCategory"
             @clickUpdateCategory="onClickUpdateCategory"
             @clickCategory="onClickCategory"
             @clickDestroyCategory="onClickDestroyCategory"
+            @clickStocksAll="onClickStocksAll"
           />
         </div>
         <div class="column is-9 column-padding">
@@ -110,6 +112,9 @@ export default class StockCategories extends Vue {
   @QiitaGetter
   lastPage!: IPage;
 
+  @QiitaGetter
+  displayCategoryId!: number;
+
   @QiitaAction
   saveCategory!: (category: string) => void;
 
@@ -138,6 +143,9 @@ export default class StockCategories extends Vue {
 
   @QiitaAction
   resetData!: () => void;
+
+  @QiitaAction
+  saveDisplayCategoryId!: (categoryId: number) => void;
 
   @Watch("$route")
   onRouteChanged() {
@@ -186,13 +194,19 @@ export default class StockCategories extends Vue {
     this.setIsCategorizing();
   }
 
+  onClickStocksAll() {
+    this.resetData();
+  }
+
   async initializeStock() {
     const query: any = this.$route.params;
+    const categoryId: number = parseInt(query.id);
     const fetchCategorizedStockPayload: IfetchCategorizedStockPayload = {
-      categoryId: parseInt(query.id),
+      categoryId: categoryId,
       page: { page: 0, perPage: 0, relation: "" }
     };
     this.fetchCategorizedStock(fetchCategorizedStockPayload);
+    this.saveDisplayCategoryId(categoryId);
   }
 
   initializeCategory() {

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -6,6 +6,7 @@
         <div class="column is-3 column-padding">
           <SideMenu
             :categories="categories"
+            :displayCategoryId="displayCategoryId"
             @clickSaveCategory="onClickSaveCategory"
             @clickUpdateCategory="onClickUpdateCategory"
             @clickDestroyCategory="onClickDestroyCategory"
@@ -102,6 +103,9 @@ export default class Stocks extends Vue {
 
   @QiitaGetter
   lastPage!: IPage;
+
+  @QiitaGetter
+  displayCategoryId!: number;
 
   @QiitaAction
   saveCategory!: (category: string) => void;

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -108,6 +108,7 @@ const state: IQiitaState = {
   categorizedStocks: [],
   currentPage: 1,
   paging: [],
+  displayCategoryId: 0,
   isCategorizing: false,
   isLoading: true
 };
@@ -133,6 +134,9 @@ const getters: GetterTree<IQiitaState, RootState> = {
   },
   categorizedStocks: (state): IQiitaState["categorizedStocks"] => {
     return state.categorizedStocks;
+  },
+  displayCategoryId: (state): IQiitaState["displayCategoryId"] => {
+    return state.displayCategoryId;
   },
   isCategorizing: (state): IQiitaState["isCategorizing"] => {
     return state.isCategorizing;
@@ -250,8 +254,14 @@ const mutations: MutationTree<IQiitaState> = {
   saveCurrentPage: (state, currentPage: number) => {
     state.currentPage = currentPage;
   },
+  saveDisplayCategoryId: (state, categoryID: number) => {
+    state.displayCategoryId = categoryID;
+  },
   setIsCategorizing: state => {
     state.isCategorizing = !state.isCategorizing;
+  },
+  restIsCategorizing: state => {
+    state.isCategorizing = false;
   },
   setIsLoading: (state, isLoading: boolean) => {
     state.isLoading = isLoading;
@@ -717,9 +727,14 @@ const actions: ActionTree<IQiitaState, RootState> = {
     commit("checkStock", { stock, isChecked: !stock.isChecked });
   },
   resetData: ({ commit }): void => {
+    commit("saveDisplayCategoryId", 0);
+    commit("restIsCategorizing");
     commit("saveCurrentPage", 1);
     commit("saveStocks", []);
     commit("saveCategorizedStocks", []);
+  },
+  saveDisplayCategoryId: ({ commit }, categoryId: number): void => {
+    commit("saveDisplayCategoryId", categoryId);
   }
 };
 

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -16,6 +16,7 @@ export interface IQiitaState {
   categorizedStocks: ICategorizedStock[];
   currentPage: number;
   paging: IPage[];
+  displayCategoryId: number;
   isCategorizing: boolean;
   isLoading: boolean;
 }

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -29,6 +29,7 @@ describe("AppHeader.vue", () => {
     categorizedStocks: [],
     currentPage: 1,
     paging: [],
+    displayCategoryId: 0,
     isCategorizing: false,
     isLoading: false
   };

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -30,6 +30,7 @@ describe("Cancel.vue", () => {
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
+      displayCategoryId: 0,
       isCategorizing: false,
       isLoading: false
     };

--- a/tests/unit/DefaultMenuList.spec.ts
+++ b/tests/unit/DefaultMenuList.spec.ts
@@ -1,0 +1,51 @@
+import { shallowMount } from "@vue/test-utils";
+import DefaultMenuList from "@/components/DefaultMenuList.vue";
+
+const $router = {
+  push: () => {}
+};
+
+describe("DefaultMenuList.vue", () => {
+  const propsData: { displayCategoryId: number } = {
+    displayCategoryId: 0
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(DefaultMenuList, {
+      propsData,
+      mocks: { $router }
+    });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickStocksAll on handleClick()", () => {
+      const wrapper = shallowMount(DefaultMenuList, {
+        propsData,
+        mocks: { $router }
+      });
+
+      // @ts-ignore
+      wrapper.vm.handleClick();
+      expect(wrapper.emitted("clickStocksAll")).toBeTruthy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call handleClick when link is clicked", () => {
+      const mock = jest.fn();
+
+      const wrapper = shallowMount(DefaultMenuList, {
+        propsData,
+        mocks: { $router }
+      });
+      wrapper.setMethods({
+        handleClick: mock
+      });
+
+      wrapper.find("a").trigger("click");
+
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -30,6 +30,7 @@ describe("Login.vue", () => {
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
+      displayCategoryId: 0,
       isCategorizing: false,
       isLoading: false
     };

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -169,6 +169,15 @@ describe("QiitaModule", () => {
       expect(categorizedStocks).toEqual(state.categorizedStocks);
     });
 
+    it("should be able to get displayCategoryId", () => {
+      const wrapper = (getters: any) => getters.displayCategoryId(state);
+      const displayCategoryId: IQiitaState["displayCategoryId"] = wrapper(
+        QiitaModule.getters
+      );
+
+      expect(displayCategoryId).toEqual(state.displayCategoryId);
+    });
+
     it("should be able to get isCategorizing", () => {
       const wrapper = (getters: any) => getters.isCategorizing(state);
       const isCategorizing: IQiitaState["isCategorizing"] = wrapper(
@@ -504,10 +513,23 @@ describe("QiitaModule", () => {
       expect(state.currentPage).toEqual(2);
     });
 
+    it("should be able to save displayCategoryId", () => {
+      const wrapper = (mutations: any) =>
+        mutations.saveDisplayCategoryId(state, 3);
+      wrapper(QiitaModule.mutations);
+      expect(state.displayCategoryId).toEqual(3);
+    });
+
     it("should be able to save isCategorizing", () => {
       const wrapper = (mutations: any) => mutations.setIsCategorizing(state);
       wrapper(QiitaModule.mutations);
       expect(state.isCategorizing).toEqual(true);
+    });
+
+    it("should be able to reset isCategorizing", () => {
+      const wrapper = (mutations: any) => mutations.restIsCategorizing(state);
+      wrapper(QiitaModule.mutations);
+      expect(state.isCategorizing).toEqual(false);
     });
 
     it("should be able to save isLoading", () => {
@@ -1039,9 +1061,23 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
+        ["saveDisplayCategoryId", 0],
+        ["restIsCategorizing"],
         ["saveCurrentPage", 1],
         ["saveStocks", []],
         ["saveCategorizedStocks", []]
+      ]);
+    });
+
+    it("should be able to save displayCategoryId", async () => {
+      const categoryId = 4;
+      const commit = jest.fn();
+      const wrapper = (actions: any) =>
+        actions.saveDisplayCategoryId({ commit }, categoryId);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([
+        ["saveDisplayCategoryId", categoryId]
       ]);
     });
   });

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -104,6 +104,7 @@ describe("QiitaModule", () => {
         categorizedStocks: categorizedStocks,
         currentPage: 1,
         paging: [firstPage, prevPage, nextPage, lastPage],
+        displayCategoryId: 0,
         isCategorizing: false,
         isLoading: false
       };
@@ -256,6 +257,7 @@ describe("QiitaModule", () => {
         categorizedStocks: [],
         currentPage: 1,
         paging: [],
+        displayCategoryId: 0,
         isCategorizing: false,
         isLoading: false
       };

--- a/tests/unit/SideMenu.spec.ts
+++ b/tests/unit/SideMenu.spec.ts
@@ -2,14 +2,16 @@ import { shallowMount, mount, config } from "@vue/test-utils";
 import SideMenu from "@/components/SideMenu.vue";
 import CreateCategory from "@/components/CreateCategory.vue";
 import CategoryList from "@/components/CategoryList.vue";
+import DefaultMenuList from "@/components/DefaultMenuList.vue";
 import { IUpdateCategoryPayload } from "@/store/modules/qiita";
 import { ICategory } from "@/domain/qiita";
 
 config.logModifiedComponents = false;
 
 describe("SideMenu.vue", () => {
-  const propsData: { categories: ICategory[] } = {
-    categories: [{ categoryId: 1, name: "テストカテゴリ" }]
+  const propsData: { categories: ICategory[]; displayCategoryId: number } = {
+    categories: [{ categoryId: 1, name: "テストカテゴリ" }],
+    displayCategoryId: 2
   };
 
   describe("methods", () => {
@@ -62,6 +64,15 @@ describe("SideMenu.vue", () => {
 
       expect(wrapper.emitted("clickDestroyCategory")).toBeTruthy();
       expect(wrapper.emitted("clickDestroyCategory")[0][0]).toEqual(categoryId);
+    });
+
+    it("should emit clickStocksAll on onClickStocksAll()", () => {
+      const wrapper = shallowMount(SideMenu, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickStocksAll();
+
+      expect(wrapper.emitted("clickStocksAll")).toBeTruthy();
     });
   });
 
@@ -160,6 +171,25 @@ describe("SideMenu.vue", () => {
       categoryList.vm.onClickDestroyCategory(categoryId);
 
       expect(mock).toHaveBeenCalledWith(categoryId);
+    });
+
+    it("should call onClickStocksAll when link is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(SideMenu, {
+        propsData,
+        mocks: { $route, $router }
+      });
+
+      wrapper.setMethods({
+        onClickStocksAll: mock
+      });
+
+      const defaultMenuList = wrapper.find(DefaultMenuList);
+
+      // @ts-ignore
+      defaultMenuList.vm.handleClick();
+
+      expect(mock).toHaveBeenCalledWith();
     });
   });
 });

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -30,6 +30,7 @@ describe("SignUp.vue", () => {
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
+      displayCategoryId: 0,
       isCategorizing: false,
       isLoading: false
     };

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -62,7 +62,8 @@ describe("StockCategories.vue", () => {
       categorize: jest.fn(),
       checkStock: jest.fn(),
       resetData: jest.fn(),
-      destroyCategory: jest.fn()
+      destroyCategory: jest.fn(),
+      saveDisplayCategoryId: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -242,6 +243,23 @@ describe("StockCategories.vue", () => {
       expect(actions.setIsCategorizing).toHaveBeenCalled();
     });
 
+    it('calls store action "resetData" on onClickStocksAll()', () => {
+      const wrapper = shallowMount(StockCategories, {
+        store,
+        localVue,
+        router
+      });
+
+      // @ts-ignore
+      wrapper.vm.onClickStocksAll();
+
+      expect(actions.resetData).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        undefined
+      );
+    });
+
     it('calls store action "fetchCategorizedStock" on initializeStock()', () => {
       const wrapper = shallowMount(StockCategories, {
         store,
@@ -252,8 +270,9 @@ describe("StockCategories.vue", () => {
       // @ts-ignore
       wrapper.vm.initializeStock();
 
+      const categoryId = 1;
       const fetchCategorizedStockPayload = {
-        categoryId: 1,
+        categoryId: categoryId,
         page: { page: 0, perPage: 0, relation: "" }
       };
 
@@ -261,6 +280,13 @@ describe("StockCategories.vue", () => {
       expect(actions.fetchCategorizedStock).toHaveBeenCalledWith(
         expect.anything(),
         fetchCategorizedStockPayload,
+        undefined
+      );
+
+      expect(actions.fetchCategorizedStock).toHaveBeenCalled();
+      expect(actions.saveDisplayCategoryId).toHaveBeenCalledWith(
+        expect.anything(),
+        categoryId,
         undefined
       );
     });
@@ -436,6 +462,22 @@ describe("StockCategories.vue", () => {
       pagination.vm.goToPage(page);
 
       expect(mock).toHaveBeenCalledWith(page);
+    });
+
+    it("should call onClickStocksAll when link is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(StockCategories, { store, localVue, router });
+
+      wrapper.setMethods({
+        onClickStocksAll: mock
+      });
+
+      const sideMenu = wrapper.find(SideMenu);
+
+      // @ts-ignore
+      sideMenu.vm.onClickStocksAll();
+
+      expect(mock).toHaveBeenCalledWith();
     });
   });
 });

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -48,6 +48,7 @@ describe("StockCategories.vue", () => {
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
+      displayCategoryId: 0,
       isCategorizing: false,
       isLoading: false
     };

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -41,6 +41,7 @@ describe("Stocks.vue", () => {
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
+      displayCategoryId: 0,
       isCategorizing: false,
       isLoading: false
     };


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/158

# Doneの定義
 https://github.com/nekochans/qiita-stocker-frontend/issues/158 の完了条件を満たしている事

# スクリーンショット
<img width="305" alt="2019-01-05 17 16 02" src="https://user-images.githubusercontent.com/32682645/50722136-a4e18180-110d-11e9-8672-e7094e60e962.png">

# 変更点概要

## 仕様的変更点概要
サイドメニューの「全てのストック」を選択時に、ストック一覧が表示されるように修正。

## 技術的変更点概要
「全てのストック」を選択時に`/stocks/all`に遷移する処理を追加。
また、サイドメニューの選択状態を制御するためにStateに選択中のカテゴリIDを保持する`displayCategoryId `を追加。
「全てのストック」、カテゴリ一覧のカテゴリ選択時に、Actionの`resetDate`を呼び出し、Stateの初期化を行なっている。