### PR TITLE
S3bucketにデプロイするスクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,29 @@ VUE_APP_QIITA_CLIENT_ID=XXXX        // Your client ID
 VUE_APP_QIITA_CLIENT_SECRET=XXXX    // Your client secret
 VUE_APP_QIITA_REDIRECT_URI=http://localhost:8080/login
 ```
+
+`.env` can be generated with npm script.
+
+For example, to generate .env for the local environment, execute the following script.
+
+`yarn run generateDotenv:local`
+
+### deploy to S3
+
+AWS credentials must be set with the following profile name.
+
+Please check that `~/.aws/credentials` is in the following state.
+
+```
+[qiita-stocker-dev]
+aws_access_key_id = Your client ID
+aws_secret_access_key = Your client secret
+
+[qiita-stocker-prod]
+aws_access_key_id = Your client ID
+aws_secret_access_key = Your client secret
+```
+
+For example, to deploy to a staging environment run the following script.
+
+`yarn run deploy:stg`

--- a/deployToS3.js
+++ b/deployToS3.js
@@ -1,0 +1,46 @@
+const s3 = require("s3");
+const path = require("path");
+const AWS = require("aws-sdk");
+const deployUtils = require("./deployUtils");
+
+const deployStage = process.env.DEPLOY_STAGE;
+if (deployUtils.isAllowedDeployStage(deployStage) === false) {
+  return Promise.reject(
+    new Error(
+      "有効なステージではありません。local, dev, stg, prod が利用出来ます。"
+    )
+  );
+}
+
+const credentials = new AWS.SharedIniFileCredentials({
+  profile: deployUtils.findAwsProfile(deployStage)
+});
+
+const client = s3.createClient({
+  s3Options: {
+    region: "ap-northeast-1",
+    credentials: credentials
+  }
+});
+
+const params = {
+  localDir: path.join(__dirname, "/dist"),
+  deleteRemoved: true,
+  s3Params: {
+    Bucket: `${deployStage}-qiita-stocker-frontend`
+  }
+};
+
+const uploader = client.uploadDir(params);
+
+uploader.on("error", function(error) {
+  console.error("unable to sync:", error.stack);
+});
+
+uploader.on("progress", function() {
+  console.log("progress", uploader.progressAmount, uploader.progressTotal);
+});
+
+uploader.on("end", function() {
+  console.log("done uploading");
+});

--- a/deployToS3.js
+++ b/deployToS3.js
@@ -27,7 +27,7 @@ const params = {
   localDir: path.join(__dirname, "/dist"),
   deleteRemoved: true,
   s3Params: {
-    Bucket: `${deployStage}-qiita-stocker-frontend`
+    Bucket: deployUtils.findDeployS3Bucket(deployStage)
   }
 };
 

--- a/deployUtils.js
+++ b/deployUtils.js
@@ -36,3 +36,13 @@ exports.findAwsProfile = deployStage => {
 
   return "qiita-stocker-dev";
 };
+
+/**
+ * デプロイ先のS3Bucket名を取得する
+ *
+ * @param deployStage
+ * @return {string}
+ */
+exports.findDeployS3Bucket = deployStage => {
+  return `${deployStage}-qiita-stocker-frontend`;
+};

--- a/deployUtils.js
+++ b/deployUtils.js
@@ -1,0 +1,38 @@
+/**
+ * 許可されたデプロイステージかどうか判定する
+ *
+ * @param deployStage
+ * @return {boolean}
+ */
+exports.isAllowedDeployStage = deployStage => {
+  return (
+    deployStage === "local" ||
+    deployStage === "dev" ||
+    deployStage === "stg" ||
+    deployStage === "prod"
+  );
+};
+
+/**
+ * SecretIdsを取得する
+ *
+ * @param deployStage
+ * @return {string[]}
+ */
+exports.findSecretIds = deployStage => {
+  return [`${deployStage}/qiita-stocker`];
+};
+
+/**
+ * AWSのプロファイル名を取得する
+ *
+ * @param deployStage
+ * @return {string}
+ */
+exports.findAwsProfile = deployStage => {
+  if (deployStage === "prod") {
+    return "qiita-stocker-prod";
+  }
+
+  return "qiita-stocker-dev";
+};

--- a/generateEnv.js
+++ b/generateEnv.js
@@ -1,0 +1,41 @@
+(async () => {
+  const deployUtils = require("./deployUtils");
+
+  const deployStage = process.env.DEPLOY_STAGE;
+  if (deployUtils.isAllowedDeployStage(deployStage) === false) {
+    return Promise.reject(
+      new Error(
+        "有効なステージではありません。local, dev, stg, prod が利用出来ます。"
+      )
+    );
+  }
+
+  const awsEnvCreator = require("@nekonomokochan/aws-env-creator");
+
+  const params = {
+    type: ".env",
+    outputDir: "./",
+    secretIds: deployUtils.findSecretIds(deployStage),
+    profile: deployUtils.findAwsProfile(deployStage),
+    region: "ap-northeast-1",
+    outputWhitelist: [
+      "BACKEND_URL",
+      "QIITA_CLIENT_ID",
+      "QIITA_CLIENT_SECRET",
+      "QIITA_REDIRECT_URI"
+    ],
+    keyMapping: {
+      BACKEND_URL: "VUE_APP_API_URL_BASE",
+      QIITA_CLIENT_ID: "VUE_APP_QIITA_CLIENT_ID",
+      QIITA_CLIENT_SECRET: "VUE_APP_QIITA_CLIENT_SECRET",
+      QIITA_REDIRECT_URI: "VUE_APP_QIITA_REDIRECT_URI"
+    },
+    addParams: {
+      VUE_APP_STAGE: deployStage
+    }
+  };
+
+  await awsEnvCreator.createEnvFile(params);
+})().catch(error => {
+  console.error(error);
+});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vuex-class": "^0.3.1"
   },
   "devDependencies": {
-    "@nekonomokochan/aws-env-creator": "^1.0.1",
+    "@nekonomokochan/aws-env-creator": "^1.1.0",
     "@types/jest": "^23.3.9",
     "@types/uuid": "^3.4.4",
     "@vue/cli-plugin-babel": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vuex-class": "^0.3.1"
   },
   "devDependencies": {
+    "@nekonomokochan/aws-env-creator": "^1.0.1",
     "@types/jest": "^23.3.9",
     "@types/uuid": "^3.4.4",
     "@vue/cli-plugin-babel": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-core": "7.0.0-bridge.0",
     "lint-staged": "^8.0.4",
     "node-sass": "^4.10.0",
+    "s3": "^4.4.0",
     "sass-loader": "^7.1.0",
     "ts-jest": "^23.10.4",
     "typescript": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generateDotenv:prod": "DEPLOY_STAGE=prod node generateEnv.js",
     "deploy:dev": "rm -rf dist && yarn run generateDotenv:dev && yarn run build && DEPLOY_STAGE=dev node deployToS3.js",
     "deploy:stg": "rm -rf dist && yarn run generateDotenv:stg && yarn run build && DEPLOY_STAGE=stg node deployToS3.js",
-    "deploy:prod": "rm -rf dist && yarn run generateDotenv:stg && yarn run build && DEPLOY_STAGE=prod node deployToS3.js"
+    "deploy:prod": "rm -rf dist && yarn run generateDotenv:prod && yarn run build && DEPLOY_STAGE=prod node deployToS3.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e"
+    "test:e2e": "vue-cli-service test:e2e",
+    "generateDotenv:local": "DEPLOY_STAGE=local node generateEnv.js",
+    "generateDotenv:dev": "DEPLOY_STAGE=dev node generateEnv.js",
+    "generateDotenv:stg": "DEPLOY_STAGE=stg node generateEnv.js",
+    "generateDotenv:prod": "DEPLOY_STAGE=prod node generateEnv.js",
+    "deploy:dev": "rm -rf dist && yarn run generateDotenv:dev && yarn run build && DEPLOY_STAGE=dev node deployToS3.js",
+    "deploy:stg": "rm -rf dist && yarn run generateDotenv:stg && yarn run build && DEPLOY_STAGE=stg node deployToS3.js",
+    "deploy:prod": "rm -rf dist && yarn run generateDotenv:stg && yarn run build && DEPLOY_STAGE=prod node deployToS3.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,9 +823,9 @@
     glob-to-regexp "^0.3.0"
 
 "@nekonomokochan/aws-env-creator@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@nekonomokochan/aws-env-creator/-/aws-env-creator-1.0.1.tgz#c031e790b9a245e072914ce4491b04495a4c8687"
-  integrity sha512-uxaxnWqulhjIh/XfsKsEKDA6/6Jf9eyKvkQ527ukKn8zods7IiZU6Tk5rEo6J7xEXRsv2Fa79cl3RmM471+YNA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nekonomokochan/aws-env-creator/-/aws-env-creator-1.1.0.tgz#daba554947fb74a41170b946a9ea8d3ff473e186"
+  integrity sha512-3H7Hrve0P/86G1C8lJ47se9W1SBHlZMEvWW0CTT0kfRuy5DBTiLqCt/gOLV1XYno0/kl1hemlVKh3yKfLZIk6Q==
   dependencies:
     aws-sdk "^2.382.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,6 +822,13 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nekonomokochan/aws-env-creator@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@nekonomokochan/aws-env-creator/-/aws-env-creator-1.0.1.tgz#c031e790b9a245e072914ce4491b04495a4c8687"
+  integrity sha512-uxaxnWqulhjIh/XfsKsEKDA6/6Jf9eyKvkQ527ukKn8zods7IiZU6Tk5rEo6J7xEXRsv2Fa79cl3RmM471+YNA==
+  dependencies:
+    aws-sdk "^2.382.0"
+
 "@nodelib/fs.stat@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
@@ -1825,6 +1832,21 @@ autoprefixer@^8.6.5:
     postcss "^6.0.23"
     postcss-value-parser "^3.2.3"
 
+aws-sdk@^2.382.0:
+  version "2.384.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.384.0.tgz#c8fdce7c72f068f6d8b198b53cf33b6f35f3e811"
+  integrity sha512-E+pIOWFNhQH7GCkOl5GU+Vl42MlaKtAq0Yenaa2fRGult9097u7TnUx45V1pNKMCN9RnEFWQy3ZH1TEPEYJ0fw==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2348,7 +2370,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
@@ -4034,7 +4056,7 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
-events@^1.0.0:
+events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -5221,6 +5243,11 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
 ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
@@ -6184,6 +6211,11 @@ jest@^23.6.0:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 joi@^13.0.0:
   version "13.7.0"
@@ -9064,7 +9096,12 @@ sass-loader@^7.1.0:
     pify "^3.0.0"
     semver "^5.5.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10287,6 +10324,14 @@ url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@0.11.0, url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -10336,6 +10381,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
@@ -10815,6 +10865,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xregexp@4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,7 +822,7 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nekonomokochan/aws-env-creator@^1.0.1":
+"@nekonomokochan/aws-env-creator@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nekonomokochan/aws-env-creator/-/aws-env-creator-1.1.0.tgz#daba554947fb74a41170b946a9ea8d3ff473e186"
   integrity sha512-3H7Hrve0P/86G1C8lJ47se9W1SBHlZMEvWW0CTT0kfRuy5DBTiLqCt/gOLV1XYno0/kl1hemlVKh3yKfLZIk6Q==
@@ -1846,6 +1846,14 @@ aws-sdk@^2.382.0:
     url "0.10.3"
     uuid "3.1.0"
     xml2js "0.4.19"
+
+aws-sdk@~2.0.31:
+  version "2.0.31"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.0.31.tgz#e72cf1fdc69015bd9fd2bdf3d3b88c16507d268e"
+  integrity sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=
+  dependencies:
+    xml2js "0.2.6"
+    xmlbuilder "0.4.2"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -4367,7 +4375,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fd-slicer@~1.0.1:
+fd-slicer@~1.0.0, fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
@@ -4523,6 +4531,11 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+findit2@~2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/findit2/-/findit2-2.2.3.tgz#58a466697df8a6205cdfdbf395536b8bd777a5f6"
+  integrity sha1-WKRmaX34piBc39vzlVNri9d3pfY=
 
 flat-cache@^1.2.1:
   version "1.3.2"
@@ -4902,6 +4915,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@~3.0.5:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
+  integrity sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=
+  dependencies:
+    natives "^1.1.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7019,6 +7039,11 @@ mime@^2.0.3, mime@^2.3.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
 
+mime@~1.2.11:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
+  integrity sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -7203,6 +7228,11 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -8988,6 +9018,11 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+  integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -9040,6 +9075,21 @@ rxjs@^6.1.0:
   integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
   dependencies:
     tslib "^1.9.0"
+
+s3@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/s3/-/s3-4.4.0.tgz#56a4f775515a7b6b9c8e5c6b1ab51f9037669f1f"
+  integrity sha1-VqT3dVFae2ucjlxrGrUfkDdmnx8=
+  dependencies:
+    aws-sdk "~2.0.31"
+    fd-slicer "~1.0.0"
+    findit2 "~2.2.3"
+    graceful-fs "~3.0.5"
+    mime "~1.2.11"
+    mkdirp "~0.5.0"
+    pend "~1.2.0"
+    rimraf "~2.2.8"
+    streamsink "~1.2.0"
 
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -9095,6 +9145,11 @@ sass-loader@^7.1.0:
     neo-async "^2.5.0"
     pify "^3.0.0"
     semver "^5.5.0"
+
+sax@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-0.4.2.tgz#39f3b601733d6bec97105b242a2a40fd6978ac3c"
+  integrity sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=
 
 sax@1.2.1:
   version "1.2.1"
@@ -9621,6 +9676,11 @@ stream-to-observable@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
   integrity sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=
+
+streamsink@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/streamsink/-/streamsink-1.2.0.tgz#efafee9f1e22d3591ed7de3dcaa95c3f5e79f73c"
+  integrity sha1-76/unx4i01ke1949yqlcP1559zw=
 
 string-argv@^0.0.2:
   version "0.0.2"
@@ -10866,6 +10926,13 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.6.tgz#d209c4e4dda1fc9c452141ef41c077f5adfdf6c4"
+  integrity sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=
+  dependencies:
+    sax "0.4.2"
+
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
@@ -10873,6 +10940,11 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xmlbuilder@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-0.4.2.tgz#1776d65f3fdbad470a08d8604cdeb1c4e540ff83"
+  integrity sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/139

# 関連URL
https://stg-www.nekochans.net/

# Doneの定義
- ステージング環境のS3BucketにSPAがデプロイ出来るようになっている事

# 変更点概要

## 仕様的変更点概要
- デプロイに必要になるpackageとnpm scriptを追加

## 技術的変更点概要
- `.env` を生成する script `generateEnv.js` を実装
- デプロイ用のscript `deployToS3.js` を実装

使い方はREADMEに記載してある通り。

`package.json` にはいろいろなscriptが定義されているが、基本的に `yarn run deploy:stg` 等を実行すればVue.jsのBuild、`.env` の生成等は一緒に行われる。

# 補足
READMEにも書いてあるが、aws-cliのクレデンシャルとAWS Secret Managerに必要な環境変数が登録されている必要がある。

AWS Secret Managerの内容はAWSコンソールにログインすれば確認可能。
https://ap-northeast-1.console.aws.amazon.com/secretsmanager/home?region=ap-northeast-1#/listSecrets