### PR TITLE
ストック一覧のストックにカテゴリを表示する

### DIFF
--- a/src/components/CategorizedStock.vue
+++ b/src/components/CategorizedStock.vue
@@ -47,7 +47,7 @@ import { ICategorizedStock } from "@/domain/qiita";
 @Component
 export default class CategorizedStock extends Vue {
   @Prop()
-  stock!: ICategorizedStock[];
+  stock!: ICategorizedStock;
 
   @Prop()
   isCategorizing!: boolean;

--- a/src/components/Stock.vue
+++ b/src/components/Stock.vue
@@ -23,9 +23,16 @@
             >{{ stock.title }}</a
           >
         </div>
-        <div class="tags">
+        <div class="tags tags-margin">
           <span v-for="(tag, key) in stock.tags" :key="key" class="tag">
             {{ tag }}
+          </span>
+        </div>
+        <div v-if="stock.category" class="tags tags-margin">
+          <span
+            class="tag has-text-white has-background-primary category-margin"
+          >
+            {{ stock.category.name }}
           </span>
         </div>
       </div>
@@ -34,6 +41,7 @@
       <input
         type="checkbox"
         :checked="stock.isChecked"
+        class="checkbox-margin"
         @change="onClickCheckStock"
       />
     </label>
@@ -47,7 +55,7 @@ import { IUncategorizedStock } from "@/domain/qiita";
 @Component
 export default class Stock extends Vue {
   @Prop()
-  stock!: IUncategorizedStock[];
+  stock!: IUncategorizedStock;
 
   @Prop()
   isCategorizing!: boolean;
@@ -85,5 +93,17 @@ a:hover {
 
 .content-no-scroll {
   overflow-x: visible;
+}
+
+.tags-margin {
+  margin-bottom: 0;
+}
+
+.category-margin {
+  margin-bottom: 0;
+}
+
+.checkbox-margin {
+  margin-left: 0.3em;
 }
 </style>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -3,10 +3,10 @@
     <div class="navbar-end">
       <div v-if="isCategorizing">
         <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
-          <select v-model="selectedCategoryId">
+          <select v-model="selectedCategory">
             <option
               v-for="category in displayCategories"
-              :value="category.categoryId"
+              :value="category"
               :key="category.categoryId"
               >{{ category.name }}</option
             >
@@ -44,7 +44,7 @@ export default class StockEdit extends Vue {
   @Prop()
   displayCategories!: ICategory[];
 
-  selectedCategoryId: number = 0;
+  selectedCategory: ICategory = { categoryId: 0, name: "" };
   isValidationError: boolean = false;
 
   doneEdit() {
@@ -61,12 +61,12 @@ export default class StockEdit extends Vue {
   }
 
   changeCategory() {
-    if (this.selectedCategoryId === 0) {
+    if (this.selectedCategory.categoryId === 0) {
       this.isValidationError = true;
       return;
     }
 
-    this.$emit("clickCategorize", this.selectedCategoryId);
+    this.$emit("clickCategorize", this.selectedCategory);
     this.doneEdit();
   }
 }

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -163,7 +163,12 @@ export interface IFetchStockRequest {
 
 export interface IFetchStockResponse {
   paging: IPage[];
-  stocks: IStock[];
+  stocks: { stock: IStock; category?: ICategory }[];
+}
+
+export interface IUncategorizedStock extends IStock {
+  category?: ICategory;
+  isChecked: boolean;
 }
 
 export interface IFetchCategorizedStockRequest {
@@ -202,10 +207,6 @@ export interface IStock {
   profile_image_url: string;
   article_created_at: string;
   tags: string[];
-}
-
-export interface IUncategorizedStock extends IStock {
-  isChecked: boolean;
 }
 
 export interface IFetchedCategorizedStock extends IStock {

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -167,9 +167,9 @@ export default class StockCategories extends Vue {
     this.destroyCategory(categoryId);
   }
 
-  onClickCategorize(categoryId: number) {
+  onClickCategorize(category: ICategory) {
     const categorizePayload: ICategorizePayload = {
-      categoryId: categoryId,
+      category: category,
       stockArticleIds: this.checkedCategorizedStockArticleIds
     };
     this.categorize(categorizePayload);

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -146,9 +146,9 @@ export default class Stocks extends Vue {
     this.destroyCategory(categoryId);
   }
 
-  onClickCategorize(categoryId: number) {
+  onClickCategorize(category: ICategory) {
     const categorizePayload: ICategorizePayload = {
-      categoryId: categoryId,
+      category: category,
       stockArticleIds: this.checkedStockArticleIds
     };
     this.categorize(categorizePayload);

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -244,7 +244,7 @@ const mutations: MutationTree<IQiitaState> = {
   saveStocks: (state, stocks: IUncategorizedStock[]) => {
     state.stocks = stocks;
   },
-  addCategoryToStocks: (
+  updateStockCategory: (
     state,
     payload: { stockArticleIds: string[]; category: ICategory }
   ) => {
@@ -729,7 +729,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
       await categorize(categorizeRequest);
       commit("uncheckStock");
       commit("removeCategorizedStocks", categorizePayload.stockArticleIds);
-      commit("addCategoryToStocks", {
+      commit("updateStockCategory", {
         stockArticleIds: categorizePayload.stockArticleIds,
         category: categorizePayload.category
       });

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -134,7 +134,6 @@ const getters: GetterTree<IQiitaState, RootState> = {
       category => category.categoryId !== state.displayCategoryId
     );
   },
-
   stocks: (state): IQiitaState["stocks"] => {
     return state.stocks;
   },
@@ -620,12 +619,13 @@ const actions: ActionTree<IQiitaState, RootState> = {
       );
 
       let uncategorizedStocks: IUncategorizedStock[] = [];
-      for (const stock of fetchStockResponse.stocks) {
-        const date: string[] = stock.article_created_at.split(" ");
-        stock.article_created_at = date[0];
-        const uncategorizedStock: IUncategorizedStock = Object.assign(stock, {
-          isChecked: false
-        });
+      for (const fetchStock of fetchStockResponse.stocks) {
+        const date: string[] = fetchStock.stock.article_created_at.split(" ");
+        fetchStock.stock.article_created_at = date[0];
+        const uncategorizedStock: IUncategorizedStock = Object.assign(
+          fetchStock.stock,
+          { isChecked: false, category: fetchStock.category }
+        );
         uncategorizedStocks.push(uncategorizedStock);
       }
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -1086,7 +1086,7 @@ describe("QiitaModule", () => {
 
     it("should be able to uncheck Stock", async () => {
       const categorizePayload: ICategorizePayload = {
-        categoryId: 1,
+        category: { categoryId: 1, name: "category" },
         stockArticleIds: ["c0a2609ae61a72dcc60f", "c0a2609ae61a72dcc60a"]
       };
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -428,7 +428,7 @@ describe("QiitaModule", () => {
       expect(state.stocks).toEqual(stocks);
     });
 
-    it("should be able to add category to stocks", () => {
+    it("should be able to update category to stocks", () => {
       state.stocks = [
         {
           article_id: "c0a2609ae61a72dcc60f",
@@ -480,7 +480,7 @@ describe("QiitaModule", () => {
         category: { categoryId: 1, name: "categoryName" }
       };
       const wrapper = (mutations: any) =>
-        mutations.addCategoryToStocks(state, payload);
+        mutations.updateStockCategory(state, payload);
       wrapper(QiitaModule.mutations);
 
       expect(state.stocks).toEqual(expectedStocks);
@@ -1134,7 +1134,7 @@ describe("QiitaModule", () => {
       ]);
     });
 
-    it("should be able to set isCategorizing", async () => {
+    it("should be able to categorize", async () => {
       const commit = jest.fn();
       const wrapper = (actions: any) => actions.setIsCategorizing({ commit });
       await wrapper(QiitaModule.actions);
@@ -1157,7 +1157,7 @@ describe("QiitaModule", () => {
         ["uncheckStock"],
         ["removeCategorizedStocks", categorizePayload.stockArticleIds],
         [
-          "addCategoryToStocks",
+          "updateStockCategory",
           {
             stockArticleIds: categorizePayload.stockArticleIds,
             category: categorizePayload.category

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -866,14 +866,46 @@ describe("QiitaModule", () => {
     });
 
     it("should be able to fetch stocks", async () => {
-      const stocks: IStock[] = [
+      const responseData: { stock: IStock; category?: ICategory }[] = [
+        {
+          stock: {
+            article_id: "c0a2609ae61a72dcc60f",
+            title: "title1",
+            user_id: "test-user1",
+            profile_image_url: "https://test.com/test/image",
+            article_created_at: "2018/09/30",
+            tags: ["laravel", "php"]
+          },
+          category: {
+            categoryId: 1,
+            name: "categoryName"
+          }
+        },
+        {
+          stock: {
+            article_id: "c0a2609ae61a72dcc60f",
+            title: "title2",
+            user_id: "test-user12",
+            profile_image_url: "https://test.com/test/image",
+            article_created_at: "2018/09/30",
+            tags: ["Vue.js", "Vuex", "TypeScript"]
+          }
+        }
+      ];
+
+      const expectedStocks: IUncategorizedStock[] = [
         {
           article_id: "c0a2609ae61a72dcc60f",
           title: "title1",
           user_id: "test-user1",
           profile_image_url: "https://test.com/test/image",
           article_created_at: "2018/09/30",
-          tags: ["laravel", "php"]
+          tags: ["laravel", "php"],
+          isChecked: false,
+          category: {
+            categoryId: 1,
+            name: "categoryName"
+          }
         },
         {
           article_id: "c0a2609ae61a72dcc60f",
@@ -881,7 +913,9 @@ describe("QiitaModule", () => {
           user_id: "test-user12",
           profile_image_url: "https://test.com/test/image",
           article_created_at: "2018/09/30",
-          tags: ["Vue.js", "Vuex", "TypeScript"]
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
         }
       ];
 
@@ -915,7 +949,7 @@ describe("QiitaModule", () => {
         '<http://127.0.0.1/api/stocks?page=2&per_page=20>; rel="prev"';
 
       const mockResponse: { data: any; headers: any } = {
-        data: stocks,
+        data: responseData,
         headers: {
           link: link
         }
@@ -931,7 +965,7 @@ describe("QiitaModule", () => {
 
       expect(commit.mock.calls).toEqual([
         ["setIsLoading", true],
-        ["saveStocks", stocks],
+        ["saveStocks", expectedStocks],
         ["savePaging", paging],
         ["saveCurrentPage", 1],
         ["setIsLoading", false]

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -428,6 +428,64 @@ describe("QiitaModule", () => {
       expect(state.stocks).toEqual(stocks);
     });
 
+    it("should be able to add category to stocks", () => {
+      state.stocks = [
+        {
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: false,
+          category: undefined
+        },
+        {
+          article_id: "c0a2609ae61a72dcc60q",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
+        }
+      ];
+
+      const expectedStocks: IUncategorizedStock[] = [
+        {
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: false,
+          category: { categoryId: 1, name: "categoryName" }
+        },
+        {
+          article_id: "c0a2609ae61a72dcc60q",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
+        }
+      ];
+
+      const payload = {
+        stockArticleIds: ["c0a2609ae61a72dcc60f"],
+        category: { categoryId: 1, name: "categoryName" }
+      };
+      const wrapper = (mutations: any) =>
+        mutations.addCategoryToStocks(state, payload);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.stocks).toEqual(expectedStocks);
+    });
+
     it("should be able to save categorized stocks", () => {
       const categorizedStocks: ICategorizedStock[] = [
         {
@@ -1097,7 +1155,14 @@ describe("QiitaModule", () => {
 
       expect(commit.mock.calls).toEqual([
         ["uncheckStock"],
-        ["removeCategorizedStocks", categorizePayload.stockArticleIds]
+        ["removeCategorizedStocks", categorizePayload.stockArticleIds],
+        [
+          "addCategoryToStocks",
+          {
+            stockArticleIds: categorizePayload.stockArticleIds,
+            category: categorizePayload.category
+          }
+        ]
       ]);
     });
 

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -159,12 +159,13 @@ describe("StockCategories.vue", () => {
         localVue,
         router
       });
+      const category = { categoryId: 1, name: "category" };
 
       // @ts-ignore
-      wrapper.vm.onClickCategorize(1);
+      wrapper.vm.onClickCategorize(category);
 
       const categorizePayload: ICategorizePayload = {
-        category: { categoryId: 1, name: "category" },
+        category,
         stockArticleIds: []
       };
 
@@ -393,7 +394,7 @@ describe("StockCategories.vue", () => {
       const stockEdit = wrapper.find(StockEdit);
 
       // @ts-ignore
-      stockEdit.vm.selectedCategoryId = 1;
+      stockEdit.vm.selectedCategory = { categoryId: 1, name: "category" };
       // @ts-ignore
       stockEdit.vm.changeCategory();
 
@@ -403,20 +404,20 @@ describe("StockCategories.vue", () => {
     it("should call onClickCategorize when button is clicked", () => {
       const mock = jest.fn();
       const wrapper = mount(StockCategories, { store, localVue, router });
+      const category = { categoryId: 1, name: "category" };
 
       wrapper.setMethods({
         onClickCategorize: mock
       });
 
       const stockEdit = wrapper.find(StockEdit);
-      const selectedCategoryId = 1;
 
       // @ts-ignore
-      stockEdit.vm.selectedCategoryId = selectedCategoryId;
+      stockEdit.vm.selectedCategory = category;
       // @ts-ignore
       stockEdit.vm.changeCategory();
 
-      expect(mock).toHaveBeenCalledWith(selectedCategoryId);
+      expect(mock).toHaveBeenCalledWith(category);
     });
 
     it("should call onClickCheckStock when checkBox is clicked", () => {

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -164,7 +164,7 @@ describe("StockCategories.vue", () => {
       wrapper.vm.onClickCategorize(1);
 
       const categorizePayload: ICategorizePayload = {
-        categoryId: 1,
+        category: { categoryId: 1, name: "category" },
         stockArticleIds: []
       };
 

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -57,19 +57,19 @@ describe("StockEdit.vue", () => {
     it("should emit clickCategorize on changeCategory()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
-      const selectedCategoryId = 1;
+      const selectedCategory = propsData.displayCategories[0];
 
       wrapper.setMethods({ doneEdit: mock });
 
       // @ts-ignore
-      wrapper.vm.selectedCategoryId = selectedCategoryId;
+      wrapper.vm.selectedCategory = selectedCategory;
 
       // @ts-ignore
       wrapper.vm.changeCategory();
       expect(mock).toBeTruthy();
       expect(wrapper.emitted("clickCategorize")).toBeTruthy();
       expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
-        selectedCategoryId
+        selectedCategory
       );
     });
 
@@ -80,7 +80,7 @@ describe("StockEdit.vue", () => {
       wrapper.setMethods({ doneEdit: mock });
 
       // @ts-ignore
-      wrapper.vm.selectedCategoryId = 0;
+      wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
 
       // @ts-ignore
       wrapper.vm.changeCategory();

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -148,12 +148,13 @@ describe("Stocks.vue", () => {
 
     it('calls store action "categorize" on onClickCategorize()', () => {
       const wrapper = shallowMount(Stocks, { store, localVue, router });
+      const category = { categoryId: 1, name: "category" };
 
       // @ts-ignore
-      wrapper.vm.onClickCategorize(1);
+      wrapper.vm.onClickCategorize(category);
 
       const categorizePayload: ICategorizePayload = {
-        category: { categoryId: 1, name: "category" },
+        category,
         stockArticleIds: []
       };
 
@@ -278,7 +279,7 @@ describe("Stocks.vue", () => {
       const stockEdit = wrapper.find(StockEdit);
 
       // @ts-ignore
-      stockEdit.vm.selectedCategoryId = 1;
+      stockEdit.vm.selectedCategory = { categoryId: 1, name: "category" };
       // @ts-ignore
       stockEdit.vm.changeCategory();
 
@@ -294,14 +295,14 @@ describe("Stocks.vue", () => {
       });
 
       const stockEdit = wrapper.find(StockEdit);
-      const selectedCategoryId = 1;
+      const category = { categoryId: 1, name: "category" };
 
       // @ts-ignore
-      stockEdit.vm.selectedCategoryId = selectedCategoryId;
+      stockEdit.vm.selectedCategory = category;
       // @ts-ignore
       stockEdit.vm.changeCategory();
 
-      expect(mock).toHaveBeenCalledWith(selectedCategoryId);
+      expect(mock).toHaveBeenCalledWith(category);
     });
 
     it("should call onClickCheckStock when checkBox is clicked", () => {

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -153,7 +153,7 @@ describe("Stocks.vue", () => {
       wrapper.vm.onClickCategorize(1);
 
       const categorizePayload: ICategorizePayload = {
-        categoryId: 1,
+        category: { categoryId: 1, name: "category" },
         stockArticleIds: []
       };
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/165

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/165 の完了条件が満たされていること

# スクリーンショット
<img width="902" alt="2019-01-10 1 54 34" src="https://user-images.githubusercontent.com/32682645/50914804-bfec2280-147a-11e9-955c-36f3a13afc80.png">

# 変更点概要

## 仕様的変更点概要
https://github.com/nekochans/qiita-stocker-backend/pull/142 の修正でストックがカテゴリに紐づいている場合、カテゴリがレスポンスに含まれるようになったので、ストック一覧のストックにカテゴリを表示する修正を行なった。

また、ストック一覧を表示した状態で、カテゴライズを行なった場合、ストック一覧の表示にもカテゴリが反映されるように修正。

## 技術的変更点概要
#### 初期表示時のカテゴリの表示
- QiitaStockerAPIのレスポンスの修正に合わせるために、ストック一覧のInterfaceである`IUncategorizedStock`を修正
- `Stock.vue`コンポーネントに、カテゴリを表示する処理を追加

#### カテゴライズ後のカテゴリの表示
- カテゴライズする際に呼び出しているActionの`categorize`に、Stateに保持しているストック一覧のカテゴリを更新する処理を追加

# 補足情報
「全てのストック」を表示した状態でカテゴリの削除を行なった場合、ストック一覧のカテゴリが非表示とならず、そのまま表示されてしまっている。この件については、別のIssueを作成し対応する予定。