### PR TITLE
カテゴリ削除時に確認メッセージを表示する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,5 +10,6 @@ export default class App extends Vue {}
 </script>
 
 <style lang="scss">
+$modal-background-background-color: rgba(10, 10, 10, 0.3);
 @import "../node_modules/bulma/bulma.sass";
 </style>

--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -1,59 +1,73 @@
 <template>
-  <li>
-    <div v-if="!editing">
-      <a
-        :data-category="category.categoryId"
-        @click="onClickCategory"
-        :class="`${isSelecting && 'is-active'}`"
-      >
-        {{ category.name }}
-
-        <p class="edit" @click="editing = true;">
-          <span class="icon"> <i class="fas fa-pencil-alt fa-lg"></i> </span>
-        </p>
-      </a>
-    </div>
-    <div v-show="editing">
-      <div class="edit-field">
-        <input
-          :class="`input input-field ${isValidationError && 'is-danger'}`"
-          type="text"
-          v-focus="editing"
-          v-model="editCategoryName"
-        />
+  <div>
+    <ConfirmModal
+      :isShow="showConfirmation"
+      :message="confirmMessage"
+      :confirmButtonText="confirmButtonText"
+      :cancelButtonText="cancelButtonText"
+      @confirmModal="confirmDestroy"
+      @cancelModal="cancelDestroy"
+    />
+    <li>
+      <div v-if="!editing">
         <a
-          class="has-text-grey is-size-7 destroy"
-          @click="onClickDestroyCategory"
+          :data-category="category.categoryId"
+          @click="onClickCategory"
+          :class="`${isSelecting && 'is-active'}`"
         >
-          <span class="icon"> <i class="far fa-trash-alt fa-2x"></i> </span>
+          {{ category.name }}
+
+          <p class="edit" @click="editing = true;">
+            <span class="icon"> <i class="fas fa-pencil-alt fa-lg"></i> </span>
+          </p>
         </a>
-        <p v-if="isValidationError" class="help is-danger">
-          カテゴリを入力してください。
-        </p>
       </div>
-      <div class="edit-field">
-        <p class="control">
-          <button
-            class="button is-small is-danger"
-            @click="onClickUpdateCategory"
+      <div v-show="editing">
+        <div class="edit-field">
+          <input
+            :class="`input input-field ${isValidationError && 'is-danger'}`"
+            type="text"
+            v-focus="editing"
+            v-model="editCategoryName"
+          />
+          <a
+            class="has-text-grey is-size-7 destroy"
+            @click="onClickDestroyCategory"
           >
-            保存
-          </button>
-          <a class="has-text-grey is-size-7 cancel" @click="doneEdit"
-            >キャンセル</a
-          >
-        </p>
+            <span class="icon"> <i class="far fa-trash-alt fa-2x"></i> </span>
+          </a>
+          <p v-if="isValidationError" class="help is-danger">
+            カテゴリを入力してください。
+          </p>
+        </div>
+        <div class="edit-field">
+          <p class="control">
+            <button
+              class="button is-small is-danger"
+              @click="onClickUpdateCategory"
+            >
+              保存
+            </button>
+            <a class="has-text-grey is-size-7 cancel" @click="doneEdit"
+              >キャンセル</a
+            >
+          </p>
+        </div>
       </div>
-    </div>
-  </li>
+    </li>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue, Prop, Watch } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
 import { IUpdateCategoryPayload } from "@/store/modules/qiita";
+import ConfirmModal from "@/components/ConfirmModal.vue";
 
 @Component({
+  components: {
+    ConfirmModal
+  },
   directives: {
     focus: function(el, binding) {
       if (binding.value) {
@@ -75,6 +89,11 @@ export default class Category extends Vue {
   editCategoryName = this.category.name;
   isValidationError: boolean = false;
   isSelecting: boolean = false;
+
+  showConfirmation: boolean = false;
+  confirmMessage: string = `${this.category.name} を削除してもよろしいですか？`;
+  confirmButtonText: string = "削除";
+  cancelButtonText: string = "キャンセル";
 
   onClickCategory() {
     if (this.editing || this.isSelecting) return;
@@ -110,6 +129,11 @@ export default class Category extends Vue {
   }
 
   onClickDestroyCategory() {
+    this.showConfirmation = true;
+  }
+
+  confirmDestroy(): void {
+    this.showConfirmation = false;
     this.$emit("clickDestroyCategory", this.category.categoryId);
     this.doneEdit();
 
@@ -118,6 +142,10 @@ export default class Category extends Vue {
         name: "stocks"
       });
     }
+  }
+
+  cancelDestroy(): void {
+    this.showConfirmation = false;
   }
 
   initializeIsSelecting() {

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="`modal ${isShow && 'is-active'}`">
-    <div class="modal-background" @click="cancelModal"></div>
+    <div class="modal-background" @click="onClickCancel"></div>
     <div class="modal-card">
       <header class="modal-card-head">
         <p class="modal-card-title">
@@ -9,10 +9,10 @@
       </header>
       <section class="modal-card-body">{{ message }}</section>
       <footer class="modal-card-foot">
-        <button class="button is-danger" @click="confirmModal">
+        <button class="button is-danger" @click="onClickConfirm">
           {{ confirmButtonText }}
         </button>
-        <button class="button" @click="cancelModal">
+        <button class="button" @click="onClickCancel">
           {{ cancelButtonText }}
         </button>
       </footer>
@@ -37,11 +37,11 @@ export default class ConfirmModal extends Vue {
   @Prop({ default: "いいえ" })
   cancelButtonText!: string;
 
-  confirmModal() {
+  onClickConfirm() {
     this.$emit("confirmModal");
   }
 
-  cancelModal() {
+  onClickCancel() {
     this.$emit("cancelModal");
   }
 }

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,0 +1,48 @@
+<template>
+  <div :class="`modal ${isShow && 'is-active'}`">
+    <div class="modal-background" @click="cancelModal"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">
+          <span class="icon"> <i class="fas fa-info-circle"></i> </span>
+        </p>
+      </header>
+      <section class="modal-card-body">{{ message }}</section>
+      <footer class="modal-card-foot">
+        <button class="button is-danger" @click="confirmModal">
+          {{ confirmButtonText }}
+        </button>
+        <button class="button" @click="cancelModal">
+          {{ cancelButtonText }}
+        </button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class ConfirmModal extends Vue {
+  @Prop()
+  isShow!: boolean;
+
+  @Prop({ default: "処理を続けてもよろしいですか？" })
+  message!: string;
+
+  @Prop({ default: "はい" })
+  confirmButtonText!: string;
+
+  @Prop({ default: "いいえ" })
+  cancelButtonText!: string;
+
+  confirmModal() {
+    this.$emit("confirmModal");
+  }
+
+  cancelModal() {
+    this.$emit("cancelModal");
+  }
+}
+</script>

--- a/tests/unit/Category.spec.ts
+++ b/tests/unit/Category.spec.ts
@@ -66,14 +66,14 @@ describe("Category.vue", () => {
       expect(wrapper.emitted("clickUpdateCategory")).toBeFalsy();
     });
 
-    it("should emit clickDestroyCategory on onClickDestroyCategory()", () => {
+    it("should emit clickDestroyCategory on confirmDestroy()", () => {
       const wrapper = shallowMount(Category, {
         propsData,
         mocks: { $route, $router }
       });
 
       // @ts-ignore
-      wrapper.vm.onClickDestroyCategory();
+      wrapper.vm.confirmDestroy();
 
       expect(wrapper.emitted("clickDestroyCategory")).toBeTruthy();
       expect(wrapper.emitted("clickDestroyCategory")[0][0]).toEqual(

--- a/tests/unit/CategoryList.spec.ts
+++ b/tests/unit/CategoryList.spec.ts
@@ -121,7 +121,7 @@ describe("CategoryList.vue", () => {
 
       const category = wrapper.find(Category);
       // @ts-ignore
-      category.vm.onClickDestroyCategory();
+      category.vm.confirmDestroy();
 
       expect(mock).toHaveBeenCalledWith(propsData.categories[0].categoryId);
     });

--- a/tests/unit/ConfirmModal.spec.ts
+++ b/tests/unit/ConfirmModal.spec.ts
@@ -1,0 +1,86 @@
+import { shallowMount } from "@vue/test-utils";
+import ConfirmModal from "@/components/ConfirmModal.vue";
+
+describe("ConfirmModal.vue", () => {
+  const propsData: {
+    isShow: boolean;
+    message: string;
+    confirmButtonText: string;
+    cancelButtonText: string;
+  } = {
+    isShow: true,
+    message: "カテゴリを削除して問題ありませんか？",
+    confirmButtonText: "削除",
+    cancelButtonText: "キャンセル"
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(ConfirmModal, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit confirmModal on onClickConfirm()", () => {
+      const wrapper = shallowMount(ConfirmModal, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickConfirm();
+      expect(wrapper.emitted("confirmModal")).toBeTruthy();
+    });
+
+    it("should emit cancelModal on onClickCancel()", () => {
+      const wrapper = shallowMount(ConfirmModal, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCancel();
+      expect(wrapper.emitted("cancelModal")).toBeTruthy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call onClickConfirm when confirm button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(ConfirmModal, { propsData });
+
+      wrapper.setMethods({
+        onClickConfirm: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(0)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onClickCancel when cancel button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(ConfirmModal, { propsData });
+
+      wrapper.setMethods({
+        onClickCancel: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onClickCancel when background button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(ConfirmModal, { propsData });
+
+      wrapper.setMethods({
+        onClickCancel: mock
+      });
+
+      wrapper
+        .findAll("div")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/162

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/162 の完了条件が満たされていること

# スクリーンショット
<img width="779" alt="2019-01-10 16 22 17" src="https://user-images.githubusercontent.com/32682645/50952498-f1ed9b00-14f3-11e9-8378-25afa9083fe6.png">

# 変更点概要

## 仕様的変更点概要
カテゴリの削除時に、確認メッセージを表示するように修正。

## 技術的変更点概要
`ConfirmModal.vue`コンポーネントを作成。
`Category.vue`に`ConfirmModal.vue`を表示する処理を作成。