### PR TITLE
カテゴリの分類する際の確認メッセージを表示

### DIFF
--- a/src/components/AlertModal.vue
+++ b/src/components/AlertModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <div :class="`modal ${isShow && 'is-active'}`">
+    <div class="modal-background" @click="onClickClose"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">
+          <span class="icon">
+            <i class="fas fa-exclamation-triangle"></i>
+          </span>
+        </p>
+      </header>
+      <section class="modal-card-body">{{ message }}</section>
+      <footer class="modal-card-foot">
+        <button class="button is-primary" @click="onClickClose">OK</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class AlertModal extends Vue {
+  @Prop()
+  isShow!: boolean;
+
+  @Prop()
+  message!: string;
+
+  onClickClose() {
+    this.$emit("closeModal");
+  }
+}
+</script>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,76 +1,95 @@
 <template>
-  <nav v-show="stocksLength && !isLoading" class="pagination" role="navigation">
-    <a
-      class="pagination-previous"
-      :disabled="!prevPage.page"
-      @click="goToPage(prevPage);"
-      >Previous</a
+  <div>
+    <ConfirmModal
+      :isShow="showConfirmation"
+      :message="confirmMessage"
+      @confirmModal="confirmPaggination"
+      @cancelModal="cancelPaggination"
+    />
+    <nav
+      v-show="stocksLength && !isLoading"
+      class="pagination"
+      role="navigation"
     >
-    <a
-      class="pagination-next"
-      :disabled="!nextPage.page"
-      @click="goToPage(nextPage);"
-      >Next page</a
-    >
-
-    <ul class="pagination-list">
-      <li>
-        <a
-          class="pagination-link"
-          v-show="showFirstEllipsis()"
-          @click="goToPage(firstPage);"
-          >{{ firstPage.page }}</a
-        >
-      </li>
-      <li>
-        <span class="pagination-ellipsis" v-show="showPrevEllipsis()"
-          >&hellip;</span
-        >
-      </li>
-      <li>
-        <a
-          class="pagination-link"
-          v-show="prevPage.page"
-          @click="goToPage(prevPage);"
-          >{{ prevPage.page }}</a
-        >
-      </li>
-      <li>
-        <a class="pagination-link is-current">{{ currentPage }}</a>
-      </li>
-      <li>
-        <a
-          class="pagination-link"
-          v-show="nextPage.page"
-          @click="goToPage(nextPage);"
-          >{{ nextPage.page }}</a
-        >
-      </li>
-      <li>
-        <span class="pagination-ellipsis" v-show="showNestEllipsis()"
-          >&hellip;</span
-        >
-      </li>
-      <li>
-        <a
-          class="pagination-link"
-          v-show="showLastPage()"
-          @click="goToPage(lastPage);"
-          >{{ lastPage.page }}</a
-        >
-      </li>
-    </ul>
-  </nav>
+      <a
+        class="pagination-previous"
+        :disabled="!prevPage.page"
+        @click="goToPage(prevPage);"
+        >Previous</a
+      >
+      <a
+        class="pagination-next"
+        :disabled="!nextPage.page"
+        @click="goToPage(nextPage);"
+        >Next page</a
+      >
+      <ul class="pagination-list">
+        <li>
+          <a
+            class="pagination-link"
+            v-show="showFirstEllipsis()"
+            @click="goToPage(firstPage);"
+            >{{ firstPage.page }}</a
+          >
+        </li>
+        <li>
+          <span class="pagination-ellipsis" v-show="showPrevEllipsis()"
+            >&hellip;</span
+          >
+        </li>
+        <li>
+          <a
+            class="pagination-link"
+            v-show="prevPage.page"
+            @click="goToPage(prevPage);"
+            >{{ prevPage.page }}</a
+          >
+        </li>
+        <li>
+          <a class="pagination-link is-current">{{ currentPage }}</a>
+        </li>
+        <li>
+          <a
+            class="pagination-link"
+            v-show="nextPage.page"
+            @click="goToPage(nextPage);"
+            >{{ nextPage.page }}</a
+          >
+        </li>
+        <li>
+          <span class="pagination-ellipsis" v-show="showNestEllipsis()"
+            >&hellip;</span
+          >
+        </li>
+        <li>
+          <a
+            class="pagination-link"
+            v-show="showLastPage()"
+            @click="goToPage(lastPage);"
+            >{{ lastPage.page }}</a
+          >
+        </li>
+      </ul>
+    </nav>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { IPage } from "@/domain/qiita";
+import ConfirmModal from "@/components/ConfirmModal.vue";
 
-@Component
+@Component({
+  components: {
+    ConfirmModal
+  }
+})
 export default class Pagination extends Vue {
   @Prop()
   isLoading!: boolean;
+
+  @Prop()
+  isCategorizing!: boolean;
 
   @Prop()
   stocksLength!: number;
@@ -90,6 +109,11 @@ export default class Pagination extends Vue {
   @Prop()
   lastPage!: { page: number; perPage: number; relation: string };
 
+  targetPage!: IPage;
+  showConfirmation: boolean = false;
+  confirmMessage: string =
+    "保存せずにページを遷移した場合、現在のストックの選択は解除されます。ページを移動してもよろしいですか？";
+
   showFirstEllipsis() {
     return this.firstPage.page !== this.prevPage.page;
   }
@@ -107,7 +131,21 @@ export default class Pagination extends Vue {
   }
 
   goToPage(page: IPage) {
-    this.$emit("clickGoToPage", page);
+    this.targetPage = page;
+
+    if (this.isCategorizing) return (this.showConfirmation = true);
+
+    this.showConfirmation = this.isCategorizing;
+    this.$emit("clickGoToPage", this.targetPage);
+  }
+
+  confirmPaggination(): void {
+    this.showConfirmation = false;
+    this.$emit("clickGoToPage", this.targetPage);
+  }
+
+  cancelPaggination(): void {
+    this.showConfirmation = false;
   }
 }
 </script>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -92,6 +92,9 @@ export default class Pagination extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
+  checkedStockArticleIds!: string[];
+
+  @Prop()
   stocksLength!: number;
 
   @Prop()
@@ -133,9 +136,9 @@ export default class Pagination extends Vue {
   goToPage(page: IPage) {
     this.targetPage = page;
 
-    if (this.isCategorizing) return (this.showConfirmation = true);
+    if (this.isCategorizing && this.checkedStockArticleIds.length)
+      return (this.showConfirmation = true);
 
-    this.showConfirmation = this.isCategorizing;
     this.$emit("clickGoToPage", this.targetPage);
   }
 

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -3,8 +3,8 @@
     <ConfirmModal
       :isShow="showConfirmation"
       :message="confirmMessage"
-      @confirmModal="confirmPaggination"
-      @cancelModal="cancelPaggination"
+      @confirmModal="confirmPagination"
+      @cancelModal="cancelaPagination"
     />
     <nav
       v-show="stocksLength && !isLoading"
@@ -139,12 +139,12 @@ export default class Pagination extends Vue {
     this.$emit("clickGoToPage", this.targetPage);
   }
 
-  confirmPaggination(): void {
+  confirmPagination(): void {
     this.showConfirmation = false;
     this.$emit("clickGoToPage", this.targetPage);
   }
 
-  cancelPaggination(): void {
+  cancelaPagination(): void {
     this.showConfirmation = false;
   }
 }

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,26 +1,35 @@
 <template>
-  <div v-show="stocksLength && !isLoading" class="navbar-menu edit-menu">
-    <div class="navbar-end">
-      <div v-if="isCategorizing">
-        <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
-          <select v-model="selectedCategory">
-            <option
-              v-for="category in displayCategories"
-              :value="category"
-              :key="category.categoryId"
-              >{{ category.name }}</option
-            >
-          </select>
+  <div>
+    <AlertModal
+      :isShow="showAlert"
+      :message="alertMessage"
+      @closeModal="closeModal"
+    />
+    <div v-show="stocksLength && !isLoading" class="navbar-menu edit-menu">
+      <div class="navbar-end">
+        <div v-if="isCategorizing">
+          <div
+            :class="`select edit-header ${isValidationError && 'is-danger'}`"
+          >
+            <select v-model="selectedCategory">
+              <option
+                v-for="category in displayCategories"
+                :value="category"
+                :key="category.categoryId"
+                >{{ category.name }}</option
+              >
+            </select>
+          </div>
+          <button class="button is-danger" @click="changeCategory">保存</button>
+          <button class="button is-white has-text-grey" @click="cancel">
+            キャンセル
+          </button>
         </div>
-        <button class="button is-danger" @click="changeCategory">保存</button>
-        <button class="button is-white has-text-grey" @click="cancel">
-          キャンセル
-        </button>
-      </div>
-      <div v-else>
-        <button class="button is-light" @click="startEdit">
-          カテゴリに分類する
-        </button>
+        <div v-else>
+          <button class="button is-light" @click="startEdit">
+            カテゴリに分類する
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -29,8 +38,13 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
+import AlertModal from "@/components/AlertModal.vue";
 
-@Component
+@Component({
+  components: {
+    AlertModal
+  }
+})
 export default class StockEdit extends Vue {
   @Prop()
   isLoading!: boolean;
@@ -44,8 +58,13 @@ export default class StockEdit extends Vue {
   @Prop()
   displayCategories!: ICategory[];
 
+  @Prop()
+  checkedStockArticleIds!: string[];
+
   selectedCategory: ICategory = { categoryId: 0, name: "" };
   isValidationError: boolean = false;
+  showAlert: boolean = false;
+  alertMessage: string = "ストックを1つ以上選択してください。";
 
   doneEdit() {
     this.isValidationError = false;
@@ -61,13 +80,17 @@ export default class StockEdit extends Vue {
   }
 
   changeCategory() {
-    if (this.selectedCategory.categoryId === 0) {
-      this.isValidationError = true;
-      return;
-    }
+    if (!this.selectedCategory.categoryId)
+      return (this.isValidationError = true);
+
+    if (!this.checkedStockArticleIds.length) return (this.showAlert = true);
 
     this.$emit("clickCategorize", this.selectedCategory);
     this.doneEdit();
+  }
+
+  closeModal() {
+    this.showAlert = false;
   }
 }
 </script>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -11,7 +11,10 @@
           <div
             :class="`select edit-header ${isValidationError && 'is-danger'}`"
           >
-            <select v-model="selectedCategory">
+            <select
+              v-model="selectedCategory"
+              @change="isValidationError = false;"
+            >
               <option
                 v-for="category in displayCategories"
                 :value="category"

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,11 +1,11 @@
 <template>
-  <div>
+  <div v-show="stocksLength && !isLoading">
     <AlertModal
       :isShow="showAlert"
       :message="alertMessage"
       @closeModal="closeModal"
     />
-    <div v-show="stocksLength && !isLoading" class="navbar-menu edit-menu">
+    <div class="navbar-menu edit-menu">
       <div class="navbar-end">
         <div v-if="isCategorizing">
           <div

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -22,6 +22,7 @@
             :isCategorizing="isCategorizing"
             :categories="categories"
             :displayCategories="displayCategories"
+            :checkedStockArticleIds="checkedCategorizedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
             @clickCategorize="onClickCategorize"
           />

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -33,6 +33,7 @@
           />
           <Pagination
             :isLoading="isLoading"
+            :isCategorizing="isCategorizing"
             :stocksLength="categorizedStocks.length"
             :currentPage="currentPage"
             :firstPage="firstPage"

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -34,6 +34,7 @@
           <Pagination
             :isLoading="isLoading"
             :isCategorizing="isCategorizing"
+            :checkedStockArticleIds="checkedCategorizedStockArticleIds"
             :stocksLength="categorizedStocks.length"
             :currentPage="currentPage"
             :firstPage="firstPage"

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -30,6 +30,7 @@
           />
           <Pagination
             :isLoading="isLoading"
+            :isCategorizing="isCategorizing"
             :stocksLength="stocks.length"
             :currentPage="currentPage"
             :firstPage="firstPage"

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -19,6 +19,7 @@
             :stocksLength="stocks.length"
             :isCategorizing="isCategorizing"
             :displayCategories="displayCategories"
+            :checkedStockArticleIds="checkedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
             @clickCategorize="onClickCategorize"
           />

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -31,6 +31,7 @@
           <Pagination
             :isLoading="isLoading"
             :isCategorizing="isCategorizing"
+            :checkedStockArticleIds="checkedStockArticleIds"
             :stocksLength="stocks.length"
             :currentPage="currentPage"
             :firstPage="firstPage"

--- a/tests/unit/AlertModal.spec.ts
+++ b/tests/unit/AlertModal.spec.ts
@@ -7,7 +7,7 @@ describe("AlertModal.vue", () => {
     message: string;
   } = {
     isShow: true,
-    message: "アラートメッセージ",
+    message: "アラートメッセージ"
   };
 
   it("props", () => {

--- a/tests/unit/AlertModal.spec.ts
+++ b/tests/unit/AlertModal.spec.ts
@@ -1,0 +1,56 @@
+import { shallowMount } from "@vue/test-utils";
+import AlertModal from "@/components/AlertModal.vue";
+
+describe("AlertModal.vue", () => {
+  const propsData: {
+    isShow: boolean;
+    message: string;
+  } = {
+    isShow: true,
+    message: "アラートメッセージ",
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(AlertModal, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit closeModal on onClickClose()", () => {
+      const wrapper = shallowMount(AlertModal, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickClose();
+      expect(wrapper.emitted("closeModal")).toBeTruthy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call onClickClose when cancel button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(AlertModal, { propsData });
+
+      wrapper.setMethods({
+        onClickClose: mock
+      });
+
+      wrapper.find("button").trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onClickClose when background button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(AlertModal, { propsData });
+
+      wrapper.setMethods({
+        onClickClose: mock
+      });
+
+      wrapper
+        .findAll("div")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/Pagination.spec.ts
+++ b/tests/unit/Pagination.spec.ts
@@ -27,6 +27,7 @@ describe("Pagination.vue", () => {
   const propsData: {
     isLoading: boolean;
     isCategorizing: boolean;
+    checkedStockArticleIds: string[];
     stocksLength: number;
     currentPage: number;
     firstPage: IPage;
@@ -36,6 +37,7 @@ describe("Pagination.vue", () => {
   } = {
     isLoading: false,
     isCategorizing: false,
+    checkedStockArticleIds: ["aabbccddee0000000000"],
     stocksLength: 20,
     currentPage: 3,
     firstPage,

--- a/tests/unit/Pagination.spec.ts
+++ b/tests/unit/Pagination.spec.ts
@@ -26,6 +26,7 @@ describe("Pagination.vue", () => {
 
   const propsData: {
     isLoading: boolean;
+    isCategorizing: boolean;
     stocksLength: number;
     currentPage: number;
     firstPage: IPage;
@@ -34,6 +35,7 @@ describe("Pagination.vue", () => {
     lastPage: IPage;
   } = {
     isLoading: false,
+    isCategorizing: false,
     stocksLength: 20,
     currentPage: 3,
     firstPage,
@@ -56,10 +58,31 @@ describe("Pagination.vue", () => {
       expect(wrapper.emitted("clickGoToPage")).toBeTruthy();
       expect(wrapper.emitted("clickGoToPage")[0][0]).toEqual(firstPage);
     });
+
+    it("should not emit clickGoToPage on goToPage()", () => {
+      propsData.isCategorizing = true;
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.goToPage(firstPage);
+      expect(wrapper.emitted("clickGoToPage")).toBeFalsy();
+    });
+
+    it("should emit clickGoToPage on confirmPagination()", () => {
+      const wrapper = shallowMount(Pagination, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.targetPage = firstPage;
+
+      // @ts-ignore
+      wrapper.vm.confirmPagination();
+      expect(wrapper.emitted("clickGoToPage")).toBeTruthy();
+      expect(wrapper.emitted("clickGoToPage")[0][0]).toEqual(firstPage);
+    });
   });
 
   describe("template", () => {
-    it("should call startEdit when previous is clicked", () => {
+    it("should call goToPage when previous is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 
@@ -74,7 +97,7 @@ describe("Pagination.vue", () => {
       expect(mock).toHaveBeenCalledWith(prevPage);
     });
 
-    it("should call startEdit when next is clicked", () => {
+    it("should call goToPage when next is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 
@@ -89,7 +112,7 @@ describe("Pagination.vue", () => {
       expect(mock).toHaveBeenCalledWith(nextPage);
     });
 
-    it("should call startEdit when first is clicked", () => {
+    it("should call goToPage when first is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 
@@ -104,7 +127,7 @@ describe("Pagination.vue", () => {
       expect(mock).toHaveBeenCalledWith(firstPage);
     });
 
-    it("should call startEdit when prev is clicked", () => {
+    it("should call goToPage when prev is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 
@@ -119,7 +142,7 @@ describe("Pagination.vue", () => {
       expect(mock).toHaveBeenCalledWith(prevPage);
     });
 
-    it("should call startEdit when next is clicked", () => {
+    it("should call goToPage when next is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 
@@ -134,7 +157,7 @@ describe("Pagination.vue", () => {
       expect(mock).toHaveBeenCalledWith(nextPage);
     });
 
-    it("should call startEdit when last is clicked", () => {
+    it("should call goToPage when last is clicked", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(Pagination, { propsData });
 

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -66,7 +66,6 @@ describe("StockCategories.vue", () => {
           tags: ["Vue.js", "Vuex", "TypeScript"],
           isChecked: false
         }
-
       ],
       currentPage: 1,
       paging: [],

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -45,7 +45,29 @@ describe("StockCategories.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [],
-      categorizedStocks: [],
+      categorizedStocks: [
+        {
+          id: 1,
+          article_id: "11111111111111111111",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: true
+        },
+        {
+          id: 2,
+          article_id: "22222222222222222222",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false
+        }
+
+      ],
       currentPage: 1,
       paging: [],
       displayCategoryId: 0,
@@ -166,7 +188,7 @@ describe("StockCategories.vue", () => {
 
       const categorizePayload: ICategorizePayload = {
         category,
-        stockArticleIds: []
+        stockArticleIds: ["11111111111111111111"]
       };
 
       expect(actions.categorize).toHaveBeenCalledWith(

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -8,6 +8,7 @@ describe("StockEdit.vue", () => {
     stocksLength: number;
     isCategorizing: boolean;
     displayCategories: ICategory[];
+    checkedStockArticleIds: string[];
   } = {
     isLoading: false,
     stocksLength: 10,
@@ -15,7 +16,8 @@ describe("StockEdit.vue", () => {
     displayCategories: [
       { categoryId: 1, name: "テストカテゴリ1" },
       { categoryId: 2, name: "テストカテゴリ2" }
-    ]
+    ],
+    checkedStockArticleIds: ["aabbccddee0000000000"]
   };
 
   it("props", () => {
@@ -73,7 +75,7 @@ describe("StockEdit.vue", () => {
       );
     });
 
-    it("should not emit clickCategorize on changeCategory()", () => {
+    it("should not emit clickCategorize on changeCategory() when category is not selected", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(StockEdit, { propsData });
 
@@ -81,6 +83,21 @@ describe("StockEdit.vue", () => {
 
       // @ts-ignore
       wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
+    });
+
+    it("should not emit clickCategorize on changeCategory() when stock is not checked", () => {
+      propsData.checkedStockArticleIds = [];
+      const mock = jest.fn();
+      const wrapper = shallowMount(StockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = propsData.displayCategories[0];
+
+      wrapper.setMethods({ doneEdit: mock });
 
       // @ts-ignore
       wrapper.vm.changeCategory();

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -37,7 +37,28 @@ describe("Stocks.vue", () => {
       permanentId: "",
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
-      stocks: [],
+      stocks: [
+      {
+        article_id: "11111111111111111111",
+        title: "title1",
+        user_id: "test-user1",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["laravel", "php"],
+        isChecked: true,
+        category: { categoryId: 1, name: "categoryName" }
+      },
+      {
+        article_id: "22222222222222222222",
+        title: "title2",
+        user_id: "test-user12",
+        profile_image_url: "https://test.com/test/image",
+        article_created_at: "2018/09/30",
+        tags: ["Vue.js", "Vuex", "TypeScript"],
+        isChecked: false,
+        category: undefined
+      }
+    ],
       categorizedStocks: [],
       currentPage: 1,
       paging: [],
@@ -155,7 +176,7 @@ describe("Stocks.vue", () => {
 
       const categorizePayload: ICategorizePayload = {
         category,
-        stockArticleIds: []
+        stockArticleIds: ["11111111111111111111"]
       };
 
       expect(actions.categorize).toHaveBeenCalledWith(

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -38,27 +38,27 @@ describe("Stocks.vue", () => {
       sessionId: "d690e4de-0a4e-4f14-a5c5-f4303fbd8a08",
       categories: [],
       stocks: [
-      {
-        article_id: "11111111111111111111",
-        title: "title1",
-        user_id: "test-user1",
-        profile_image_url: "https://test.com/test/image",
-        article_created_at: "2018/09/30",
-        tags: ["laravel", "php"],
-        isChecked: true,
-        category: { categoryId: 1, name: "categoryName" }
-      },
-      {
-        article_id: "22222222222222222222",
-        title: "title2",
-        user_id: "test-user12",
-        profile_image_url: "https://test.com/test/image",
-        article_created_at: "2018/09/30",
-        tags: ["Vue.js", "Vuex", "TypeScript"],
-        isChecked: false,
-        category: undefined
-      }
-    ],
+        {
+          article_id: "11111111111111111111",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: true,
+          category: { categoryId: 1, name: "categoryName" }
+        },
+        {
+          article_id: "22222222222222222222",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
+        }
+      ],
       categorizedStocks: [],
       currentPage: 1,
       paging: [],


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/161

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/161 の完了条件が満たされていること

# スクリーンショット
- カテゴライズ中に、ストックが選択されずに保存ボタンが押下された場合
<img width="713" alt="2019-01-10 20 01 39" src="https://user-images.githubusercontent.com/32682645/50964419-941c7b80-1512-11e9-89f0-5f8ced81239c.png">

- カテゴライズ中に、保存ボタンが押下されずに、他のページを表示した場合
<img width="700" alt="2019-01-10 20 02 18" src="https://user-images.githubusercontent.com/32682645/50964454-a8f90f00-1512-11e9-83c3-f0ed22fac3f2.png">

# 変更点概要

## 仕様的変更点概要
- カテゴライズ中に、ストックが選択されずに保存ボタンが押下された場合にメッセージが表示されるように修正
- カテゴライズ中に、保存ボタンが押下されずに、他のページを表示した場合にッセージが表示されるように修正

## 技術的変更点概要
### ストックが選択されずに保存ボタンが押下された場合
`AlertModal.vue`コンポーネントを作成。
`StockEdit.vue`に、ストックが1つも選択されていなかった場合、`AlertModal.vue`コンポーネントを表示する処理を追加。

### 保存ボタンが押下されずに、他のページを表示した場合
`Pagination.vue`に、カテゴライズ中、かつ、ストックが選択されていた場合、`ConfirmModal.vue`コンポーネントを表示する処理を追加。

また今回のIssueとは関係ないが、カテゴライズ中にバリデーションエラーとなった後に、リストメニューのカテゴリを変更した場合、バリデーションのエラー表示を解除する処理を追加。
<img width="455" alt="2019-01-10 20 08 50" src="https://user-images.githubusercontent.com/32682645/50964809-94694680-1513-11e9-8934-f383a2734226.png">
