### PR TITLE
カテゴリ一覧で行なったカテゴリの修正をストックに反映する処理を追加

### DIFF
--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -254,6 +254,14 @@ const mutations: MutationTree<IQiitaState> = {
       }
     });
   },
+  updateStockCategoryName: (state, category: ICategory) => {
+    state.stocks.map(stock => {
+      console.log(category.categoryId);
+      if (stock.category && stock.category.categoryId === category.categoryId) {
+        stock.category = category;
+      }
+    });
+  },
   removeCategoryFromStock: (state, categoryId: number) => {
     state.stocks.map(stock => {
       if (stock.category && stock.category.categoryId == categoryId) {
@@ -578,6 +586,10 @@ const actions: ActionTree<IQiitaState, RootState> = {
       commit("updateCategory", {
         stateCategory: updateCategoryItem.stateCategory,
         categoryName: updateCategoryResponse.name
+      });
+      commit("updateStockCategoryName", {
+        categoryId: updateCategoryItem.stateCategory.categoryId,
+        name: updateCategoryResponse.name
       });
     } catch (error) {
       if (isUnauthorized(error.response.status)) {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -254,6 +254,13 @@ const mutations: MutationTree<IQiitaState> = {
       }
     });
   },
+  removeCategoryFromStock: (state, categoryId: number) => {
+    state.stocks.map(stock => {
+      if (stock.category && stock.category.categoryId == categoryId) {
+        stock.category = undefined;
+      }
+    });
+  },
   saveCategorizedStocks: (state, stocks: ICategorizedStock[]) => {
     state.categorizedStocks = stocks;
   },
@@ -596,6 +603,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
 
       await destroyCategory(destroyCategoryRequest);
       commit("removeCategory", categoryId);
+      commit("removeCategoryFromStock", categoryId);
     } catch (error) {
       if (isUnauthorized(error.response.status)) {
         localStorage.remove(STORAGE_KEY_SESSION_ID);

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -486,6 +486,69 @@ describe("QiitaModule", () => {
       expect(state.stocks).toEqual(expectedStocks);
     });
 
+    it("should be able to update stock category name", () => {
+      state.stocks = [
+        {
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: false,
+          category: { categoryId: 1, name: "categoryName" }
+        },
+        {
+          article_id: "c0a2609ae61a72dcc60q",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
+        }
+      ];
+
+      const changedCategory = { categoryId: 1, name: "changedCategoryName" };
+      const wrapper = (mutations: any) =>
+        mutations.updateStockCategoryName(state, changedCategory);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.stocks[0].category).toEqual(changedCategory);
+    });
+
+    it("should be able to remove category from stock", () => {
+      state.stocks = [
+        {
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: false,
+          category: { categoryId: 1, name: "categoryName" }
+        },
+        {
+          article_id: "c0a2609ae61a72dcc60q",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false,
+          category: undefined
+        }
+      ];
+
+      const wrapper = (mutations: any) =>
+        mutations.removeCategoryFromStock(state, 1);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.stocks[0].category).toEqual(undefined);
+    });
+
     it("should be able to save categorized stocks", () => {
       const categorizedStocks: ICategorizedStock[] = [
         {
@@ -906,7 +969,14 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
-        ["updateCategory", updateCategoryItem]
+        ["updateCategory", updateCategoryItem],
+        [
+          "updateStockCategoryName",
+          {
+            categoryId: updateCategoryItem.stateCategory.categoryId,
+            name: updateCategoryItem.categoryName
+          }
+        ]
       ]);
     });
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -920,7 +920,10 @@ describe("QiitaModule", () => {
         actions.destroyCategory({ commit }, categoryId);
       await wrapper(QiitaModule.actions);
 
-      expect(commit.mock.calls).toEqual([["removeCategory", categoryId]]);
+      expect(commit.mock.calls).toEqual([
+        ["removeCategory", categoryId],
+        ["removeCategoryFromStock", categoryId]
+      ]);
     });
 
     it("should be able to fetch stocks", async () => {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/172

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/172 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
「全てのストック」を表示した状態で、カテゴリの削除・カテゴリ名の修正を行なった場合、変更の内容がストック一覧に反映されるように修正した。

Issueの完了の定義には、カテゴリ名の修正を行なったケースは記載していないが、合わせて対応。

## 技術的変更点概要
QiitaModuleのアクションに、Stateの`Stocks`を更新する処理を追加