### PR TITLE
公式ツイッターへのリンクをフッターに追加する

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -7,6 +7,9 @@
             <ul>
               <li><a href="#">利用規約</a></li>
               <li><a href="#">プライバシーポリシー</a></li>
+              <li>
+                <a href="https://twitter.com/mindexer_org">公式Twitter</a>
+              </li>
               <li><a href="/cancel">退会</a></li>
             </ul>
           </div>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/164

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/164 の完了条件が満たされていること

# スクリーンショット
<img width="474" alt="2019-01-11 1 50 18" src="https://user-images.githubusercontent.com/32682645/50983667-466c3700-1543-11e9-9a25-0442303d6b2a.png">

# 変更点概要
## 技術的変更点概要
フッターに「[公式Twitter](https://twitter.com/mindexer_org)」を追加

# 補足情報
Twitterの説明欄に「お問い合わせはDMまでお願いします」を追加して、問い合わせ方法がわかるように記載する予定。