### PR TITLE
カテゴリ削除後のメニュー選択状態の制御を修正する

### DIFF
--- a/src/components/Category.vue
+++ b/src/components/Category.vue
@@ -91,7 +91,7 @@ export default class Category extends Vue {
   isSelecting: boolean = false;
 
   showConfirmation: boolean = false;
-  confirmMessage: string = `${this.category.name} を削除してもよろしいですか？`;
+  confirmMessage: string = this.buildConfirmMessage(this.category.name);
   confirmButtonText: string = "削除";
   cancelButtonText: string = "キャンセル";
 
@@ -125,7 +125,9 @@ export default class Category extends Vue {
     };
 
     this.$emit("clickUpdateCategory", updateCategoryPayload);
-    this.doneEdit();
+    this.confirmMessage = this.buildConfirmMessage(this.editCategoryName);
+    this.isValidationError = false;
+    this.editing = false;
   }
 
   onClickDestroyCategory() {
@@ -135,7 +137,6 @@ export default class Category extends Vue {
   confirmDestroy(): void {
     this.showConfirmation = false;
     this.$emit("clickDestroyCategory", this.category.categoryId);
-    this.doneEdit();
 
     if (this.isSelecting) {
       this.$router.push({
@@ -146,6 +147,10 @@ export default class Category extends Vue {
 
   cancelDestroy(): void {
     this.showConfirmation = false;
+  }
+
+  buildConfirmMessage(categoryName: string): string {
+    return `${categoryName} を削除してもよろしいですか？`;
   }
 
   initializeIsSelecting() {

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -4,7 +4,7 @@
     <ul class="menu-list">
       <Category
         v-for="category in categories"
-        :key="category.id"
+        :key="category.categoryId"
         :category="category"
         @clickUpdateCategory="onClickUpdateCategory"
         @clickCategory="onClickCategory"

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -616,6 +616,8 @@ const actions: ActionTree<IQiitaState, RootState> = {
       await destroyCategory(destroyCategoryRequest);
       commit("removeCategory", categoryId);
       commit("removeCategoryFromStock", categoryId);
+      if (state.displayCategoryId === categoryId)
+        return commit("saveDisplayCategoryId", 0);
     } catch (error) {
       if (isUnauthorized(error.response.status)) {
         localStorage.remove(STORAGE_KEY_SESSION_ID);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/182

# Doneの定義
選択中のカテゴリを削除した後、「全てのストック」メニューが選択された状態となっていること

# 変更点概要

## 仕様的変更点概要
選択中のカテゴリを削除した後、「全てのストック」メニューに選択状態のスタイルが適用されるように修正。

また、Issueに記載した内容以外にも、下記の不具合が発生していたため合わせて対応を行なった。
- 下記の通り、カテゴリが複数ある状態でカテゴリAを削除した場合、カテゴリBの選択中のスタイルが解除される
 -> カテゴリAを削除した後も、カテゴリBが選択中となるように修正。
```
カテゴリA <- 削除する
カテゴリB <- 選択中
```

- カテゴリ名を編集し保存した後に、再度「編集」ボタンを押下するとInputの中身が編集前のカテゴリ名に戻っている
 -> 編集後のカテゴリ名が表示されるように修正。

- カテゴリ名を編集し保存した後に、そのカテゴリを削除しようとすると、確認メッセージが編集前のカテゴリ名になってしまっている
 -> 編集後のカテゴリ名が表示されるように修正。

## 技術的変更点概要
カテゴリ操作時の動作を修正。
詳細は、仕様的変更点概要に記載の通り。