### PR TITLE
ログイン後にLocalStorageに保存しているデータを削除する処理を追加

### DIFF
--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -416,8 +416,9 @@ const actions: ActionTree<IQiitaState, RootState> = {
         name: "error",
         params: { errorMessage: error.response.data.message }
       });
-      return;
     }
+    localStorage.remove(STORAGE_KEY_AUTH_STATE);
+    localStorage.remove(STORAGE_KEY_ACCOUNT_ACTION);
   },
   issueLoginSession: async ({ commit }) => {
     try {
@@ -447,8 +448,9 @@ const actions: ActionTree<IQiitaState, RootState> = {
         name: "error",
         params: { errorMessage: error.response.data.message }
       });
-      return;
     }
+    localStorage.remove(STORAGE_KEY_AUTH_STATE);
+    localStorage.remove(STORAGE_KEY_ACCOUNT_ACTION);
   },
   logout: async ({ commit }) => {
     try {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/187

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/187 の完了の条件が満たされていること

# 変更点概要

## 仕様的変更点概要
アカウント作成、ログイン後に、LocalStorageに保存していたデータを削除する処理を追加。

## 技術的変更点概要
ModuleにLocalStorageからデータを削除する処理を追加。