### PR TITLE
カテゴライズ解除APIへのリクエスト機能を作成

### DIFF
--- a/src/components/CategorizedStock.vue
+++ b/src/components/CategorizedStock.vue
@@ -37,6 +37,13 @@
         @change="onClickCheckStock"
       />
     </label>
+    <p
+      v-show="!isCategorizing"
+      class="times-circle"
+      @click="onClickCancelCategorization"
+    >
+      <span class="icon"> <i class="far fa-times-circle fa-2x"></i> </span>
+    </p>
   </article>
 </template>
 
@@ -54,6 +61,10 @@ export default class CategorizedStock extends Vue {
 
   onClickCheckStock() {
     this.$emit("clickCheckStock", this.stock);
+  }
+
+  onClickCancelCategorization() {
+    this.$emit("clickCancelCategorization", this.stock.id);
   }
 }
 </script>
@@ -85,5 +96,21 @@ a:hover {
 
 .content-no-scroll {
   overflow-x: visible;
+}
+
+.times-circle {
+  color: darkgray;
+  display: none;
+  float: right;
+  transition: color 0.2s ease-out;
+  padding: 0.5rem;
+}
+
+.times-circle:hover {
+  color: gray;
+}
+
+article:hover .times-circle {
+  display: block;
 }
 </style>

--- a/src/components/CategorizedStockList.vue
+++ b/src/components/CategorizedStockList.vue
@@ -8,6 +8,7 @@
         :key="stock.id"
         :isCategorizing="isCategorizing"
         @clickCheckStock="onClickCheckStock"
+        @clickCancelCategorization="onClickCancelCategorization"
       />
     </div>
     <div v-else><h1 class="subtitle">ストックされた記事はありません。</h1></div>
@@ -36,6 +37,10 @@ export default class CategorizedStockList extends Vue {
 
   onClickCheckStock(stock: ICategorizedStock) {
     this.$emit("clickCheckStock", stock);
+  }
+
+  onClickCancelCategorization(categorizedStockId: number) {
+    this.$emit("clickCancelCategorization", categorizedStockId);
   }
 }
 </script>

--- a/src/domain/qiita.ts
+++ b/src/domain/qiita.ts
@@ -37,6 +37,7 @@ export interface IQiitaStockerApi {
     request: IFetchCategorizedStockRequest
   ): Promise<IFetchCategorizedStockResponse>;
   categorize(request: ICategorizeRequest): Promise<void>;
+  cancelCategorization(request: ICancelCategorizationRequest): Promise<void>;
 }
 
 export interface IQiitaApi {
@@ -191,6 +192,12 @@ export interface ICategorizeRequest {
   articleIds: string[];
 }
 
+export interface ICancelCategorizationRequest {
+  apiUrlBase: string;
+  sessionId: string;
+  id: number;
+}
+
 export interface IQiitaStockerError extends AxiosError {
   response: AxiosResponse<IQiitaStockerErrorData>;
 }
@@ -300,6 +307,12 @@ export const categorize = async (
   request: ICategorizeRequest
 ): Promise<void> => {
   return await qiitaStockerApi.categorize(request);
+};
+
+export const cancelCategorization = async (
+  request: ICancelCategorizationRequest
+): Promise<void> => {
+  return await qiitaStockerApi.cancelCategorization(request);
 };
 
 export const matchState = (responseState: string, state: string): boolean => {

--- a/src/infrastructure/api/qiitaStockerApi.ts
+++ b/src/infrastructure/api/qiitaStockerApi.ts
@@ -20,7 +20,8 @@ import {
   ICategorizeRequest,
   IFetchCategorizedStockRequest,
   IFetchCategorizedStockResponse,
-  IDestroyCategoryRequest
+  IDestroyCategoryRequest,
+  ICancelCategorizationRequest
 } from "@/domain/qiita";
 
 export default class QiitaStockerApi implements IQiitaStockerApi {
@@ -253,6 +254,23 @@ export default class QiitaStockerApi implements IQiitaStockerApi {
           }
         }
       )
+      .then((axiosResponse: AxiosResponse) => {
+        return Promise.resolve();
+      })
+      .catch((axiosError: IQiitaStockerError) => {
+        return Promise.reject(axiosError);
+      });
+  }
+
+  async cancelCategorization(
+    request: ICancelCategorizationRequest
+  ): Promise<void> {
+    return await axios
+      .delete(`${request.apiUrlBase}/api/categories/stocks/${request.id}`, {
+        headers: {
+          Authorization: `Bearer ${request.sessionId}`
+        }
+      })
       .then((axiosResponse: AxiosResponse) => {
         return Promise.resolve();
       })

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -31,6 +31,7 @@
             :isCategorizing="isCategorizing"
             :isLoading="isLoading"
             @clickCheckStock="onClickCheckStock"
+            @clickCancelCategorization="onClickCancelCategorization"
           />
           <Pagination
             :isLoading="isLoading"
@@ -141,6 +142,9 @@ export default class StockCategories extends Vue {
   categorize!: (categorizePayload: ICategorizePayload) => void;
 
   @QiitaAction
+  cancelCategorization!: (categorizedStockId: number) => void;
+
+  @QiitaAction
   checkCategorizedStock!: (stock: ICategorizedStock) => void;
 
   @QiitaAction
@@ -176,6 +180,10 @@ export default class StockCategories extends Vue {
       stockArticleIds: this.checkedCategorizedStockArticleIds
     };
     this.categorize(categorizePayload);
+  }
+
+  onClickCancelCategorization(categorizedStockId: number) {
+    this.cancelCategorization(categorizedStockId);
   }
 
   onClickCheckStock(stock: ICategorizedStock) {

--- a/tests/unit/CategorizedStock.spec.ts
+++ b/tests/unit/CategorizedStock.spec.ts
@@ -34,6 +34,18 @@ describe("CategorizedStock.vue", () => {
       expect(wrapper.emitted("clickCheckStock")).toBeTruthy();
       expect(wrapper.emitted("clickCheckStock")[0][0]).toEqual(stock);
     });
+
+    it("should emit clickCancelCategorization on onClickCancelCategorization()", () => {
+      const wrapper = shallowMount(CategorizedStock, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCancelCategorization();
+
+      expect(wrapper.emitted("clickCancelCategorization")).toBeTruthy();
+      expect(wrapper.emitted("clickCancelCategorization")[0][0]).toEqual(
+        stock.id
+      );
+    });
   });
 
   describe("template", () => {
@@ -46,6 +58,21 @@ describe("CategorizedStock.vue", () => {
       });
 
       wrapper.find("input").trigger("change");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onClickCancelCategorization when icon is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStock, { propsData });
+
+      wrapper.setMethods({
+        onClickCancelCategorization: mock
+      });
+
+      wrapper
+        .findAll("p")
+        .at(1)
+        .trigger("click");
       expect(mock).toHaveBeenCalled();
     });
   });

--- a/tests/unit/CategorizedStockList.spec.ts
+++ b/tests/unit/CategorizedStockList.spec.ts
@@ -54,6 +54,18 @@ describe("CategorizedStockList.vue", () => {
       expect(wrapper.emitted("clickCheckStock")).toBeTruthy();
       expect(wrapper.emitted("clickCheckStock")[0][0]).toEqual(stocks[0]);
     });
+
+    it("should emit clickCancelCategorization on onClickCancelCategorization()", () => {
+      const wrapper = shallowMount(CategorizedStockList, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCancelCategorization(stocks[0].id);
+
+      expect(wrapper.emitted("clickCancelCategorization")).toBeTruthy();
+      expect(wrapper.emitted("clickCancelCategorization")[0][0]).toEqual(
+        stocks[0].id
+      );
+    });
   });
 
   describe("template", () => {
@@ -71,6 +83,22 @@ describe("CategorizedStockList.vue", () => {
       categorizedStock.vm.onClickCheckStock();
 
       expect(mock).toHaveBeenCalledWith(stocks[0]);
+    });
+
+    it("should call clickCancelCategorization when icon is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(CategorizedStockList, { propsData });
+
+      wrapper.setMethods({
+        onClickCancelCategorization: mock
+      });
+
+      const categorizedStock = wrapper.find(CategorizedStock);
+
+      // @ts-ignore
+      categorizedStock.vm.onClickCancelCategorization();
+
+      expect(mock).toHaveBeenCalledWith(stocks[0].id);
     });
 
     it("renders list", () => {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -612,6 +612,39 @@ describe("QiitaModule", () => {
       expect(state.categorizedStocks).toEqual([categorizedStocks[1]]);
     });
 
+    it("should be able to remove categorized stocks by id", () => {
+      const categorizedStocks: ICategorizedStock[] = [
+        {
+          id: 1,
+          article_id: "removeid111111111111",
+          title: "title1",
+          user_id: "test-user1",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["laravel", "php"],
+          isChecked: true
+        },
+        {
+          id: 2,
+          article_id: "c0a2609ae61a72dcc60f",
+          title: "title2",
+          user_id: "test-user12",
+          profile_image_url: "https://test.com/test/image",
+          article_created_at: "2018/09/30",
+          tags: ["Vue.js", "Vuex", "TypeScript"],
+          isChecked: false
+        }
+      ];
+      const id = 1;
+
+      state.categorizedStocks = categorizedStocks;
+      const wrapper = (mutations: any) =>
+        mutations.removeCategorizedStocksById(state, id);
+      wrapper(QiitaModule.mutations);
+
+      expect(state.categorizedStocks).toEqual([categorizedStocks[1]]);
+    });
+
     it("should be able to save paging", () => {
       const paging: IPage[] = [
         {
@@ -1207,7 +1240,7 @@ describe("QiitaModule", () => {
       ]);
     });
 
-    it("should be able to categorize", async () => {
+    it("should be able to set isCategorizing", async () => {
       const commit = jest.fn();
       const wrapper = (actions: any) => actions.setIsCategorizing({ commit });
       await wrapper(QiitaModule.actions);
@@ -1215,7 +1248,7 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([["setIsCategorizing"]]);
     });
 
-    it("should be able to uncheck Stock", async () => {
+    it("should be able to categorize", async () => {
       const categorizePayload: ICategorizePayload = {
         category: { categoryId: 1, name: "category" },
         stockArticleIds: ["c0a2609ae61a72dcc60f", "c0a2609ae61a72dcc60a"]
@@ -1236,6 +1269,21 @@ describe("QiitaModule", () => {
             category: categorizePayload.category
           }
         ]
+      ]);
+    });
+
+    it("should be able to categorize", async () => {
+      const mockAxios: any = axios;
+      mockAxios.delete.mockResolvedValue({});
+      const commit = jest.fn();
+
+      const categorizedStockId = 1;
+      const wrapper = (actions: any) =>
+        actions.cancelCategorization({ commit }, categorizedStockId);
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([
+        ["removeCategorizedStocksById", categorizedStockId]
       ]);
     });
 

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -84,7 +84,8 @@ describe("StockCategories.vue", () => {
       checkCategorizedStock: jest.fn(),
       resetData: jest.fn(),
       destroyCategory: jest.fn(),
-      saveDisplayCategoryId: jest.fn()
+      saveDisplayCategoryId: jest.fn(),
+      cancelCategorization: jest.fn()
     };
 
     store = new Vuex.Store({
@@ -193,6 +194,24 @@ describe("StockCategories.vue", () => {
       expect(actions.categorize).toHaveBeenCalledWith(
         expect.anything(),
         categorizePayload,
+        undefined
+      );
+    });
+
+    it('calls store action "cancelCategorization" on onClickCancelCategorization()', () => {
+      const wrapper = shallowMount(StockCategories, {
+        store,
+        localVue,
+        router
+      });
+      const categorizedStockId = 1;
+
+      // @ts-ignore
+      wrapper.vm.onClickCancelCategorization(categorizedStockId);
+
+      expect(actions.cancelCategorization).toHaveBeenCalledWith(
+        expect.anything(),
+        categorizedStockId,
         undefined
       );
     });
@@ -439,6 +458,23 @@ describe("StockCategories.vue", () => {
       stockEdit.vm.changeCategory();
 
       expect(mock).toHaveBeenCalledWith(category);
+    });
+
+    it("should call onClickCancelCategorization when icon is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(StockCategories, { store, localVue, router });
+      const categorizedStockId = 1;
+
+      wrapper.setMethods({
+        onClickCancelCategorization: mock
+      });
+
+      const categorizedStockList = wrapper.find(CategorizedStockList);
+
+      // @ts-ignore
+      categorizedStockList.vm.onClickCancelCategorization(categorizedStockId);
+
+      expect(mock).toHaveBeenCalledWith(categorizedStockId);
     });
 
     it("should call onClickCheckStock when checkBox is clicked", () => {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/184

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/184 の完了条件が満たされていること

# スクリーンショット
<img width="1214" alt="2019-01-25 11 49 35" src="https://user-images.githubusercontent.com/32682645/51722035-64837c80-2097-11e9-9fb5-e568793420b5.png">

# 変更点概要

## 仕様的変更点概要
カテゴリを選択した場合に表示されるストック一覧に[×]ボタンを表示。
ボタンを押下することで、そのストックのカテゴライズを解除する。
「全てのストック」を選択した場合のストック一覧には[×]ボタンは表示されない。

## 技術的変更点概要
カテゴライズ解除APIへのリクエスト処理を作成。
`CategorizedStock.vue`コンポーネントに、カテゴライズ解除APIへのリクエストを送信するためのアイコンを追加。