### PR TITLE
カテゴライズ解除ボタンのUIを改善する

### DIFF
--- a/public/index.prod.html
+++ b/public/index.prod.html
@@ -8,12 +8,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="<%= BASE_URL %>apple-touch-icon.png">
     <title>Mindexer | Qiitaのストックを整理するためのサービスです</title>
     <meta name="description" content="Mindexerは、Qiitaのストックにカテゴリ機能を追加したサービスです。">
-    <meta property="og:url" content="<%= BASE_URL %>" />
+    <meta property="og:url" content="https://www.mindexer.net" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Mindexer | Qiitaのストックを整理するためのサービスです" />
     <meta property="og:description" content="Mindexerは、Qiitaのストックにカテゴリ機能を追加したサービスです。" />
     <meta property="og:site_name" content="Mindexer" />
-    <meta property="og:image" content="https://mindexer.net/ogp.png" />
+    <meta property="og:image" content="https://www.mindexer.net/ogp.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@mindexer_org" />
   </head>

--- a/public/index.stg.html
+++ b/public/index.stg.html
@@ -9,7 +9,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="<%= BASE_URL %>apple-touch-icon.png">
     <title>Mindexer | Qiitaのストックを整理するためのサービスです</title>
     <meta name="description" content="Mindexerは、  Qiitaのストックにカテゴリ機能を追加したサービスです。">
-    <meta property="og:url" content="<%= BASE_URL %>" />
+    <meta property="og:url" content="https://stg-www.nekochans.net" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Mindexer | Qiitaのストックを整理するためのサービスです" />
     <meta property="og:description" content="Mindexerは、Qiitaのストックにカテゴリ機能を追加したサービスです。" />

--- a/src/components/CategorizeButton.vue
+++ b/src/components/CategorizeButton.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <AlertModal
+      :isShow="showAlert"
+      :message="alertMessage"
+      @closeModal="closeModal"
+    />
+    <div v-if="isCategorizing">
+      <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
+        <select v-model="selectedCategory" @change="isValidationError = false;">
+          <option
+            v-for="category in displayCategories"
+            :value="category"
+            :key="category.categoryId"
+            >{{ category.name }}</option
+          >
+        </select>
+      </div>
+      <button class="button is-danger button-margin" @click="changeCategory">
+        保存
+      </button>
+      <button
+        class="button is-white has-text-grey button-margin"
+        @click="cancel"
+      >
+        キャンセル
+      </button>
+    </div>
+    <div v-show="!isCancelingCategorizing" v-else>
+      <button class="button is-light button-margin" @click="startEdit">
+        カテゴリに分類する
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { ICategory } from "@/domain/qiita";
+import AlertModal from "@/components/AlertModal.vue";
+
+@Component({
+  components: {
+    AlertModal
+  }
+})
+export default class CategorizeButton extends Vue {
+  @Prop()
+  isCategorizing!: boolean;
+
+  @Prop()
+  isCancelingCategorizing!: boolean;
+
+  @Prop()
+  displayCategories!: ICategory[];
+
+  @Prop()
+  checkedStockArticleIds!: string[];
+
+  selectedCategory: ICategory = { categoryId: 0, name: "" };
+  isValidationError: boolean = false;
+  showAlert: boolean = false;
+  alertMessage: string = "ストックを1つ以上選択してください。";
+
+  doneEdit() {
+    this.isValidationError = false;
+    this.$emit("clickSetIsCategorizing");
+  }
+
+  startEdit() {
+    this.doneEdit();
+  }
+
+  cancel() {
+    this.doneEdit();
+  }
+
+  changeCategory() {
+    if (!this.selectedCategory.categoryId)
+      return (this.isValidationError = true);
+
+    if (!this.checkedStockArticleIds.length) return (this.showAlert = true);
+
+    this.$emit("clickCategorize", this.selectedCategory);
+    this.doneEdit();
+  }
+
+  closeModal() {
+    this.showAlert = false;
+  }
+}
+</script>
+
+<style scoped>
+.edit-header {
+  margin-right: 10px;
+}
+
+.button-margin {
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/src/components/CategorizeButton.vue
+++ b/src/components/CategorizeButton.vue
@@ -26,7 +26,7 @@
         キャンセル
       </button>
     </div>
-    <div v-show="!isCancelingCategorizing" v-else>
+    <div v-show="!isCancelingCategorization" v-else>
       <button class="button is-light button-margin" @click="startEdit">
         カテゴリに分類する
       </button>
@@ -49,7 +49,7 @@ export default class CategorizeButton extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @Prop()
   displayCategories!: ICategory[];

--- a/src/components/CategorizedStock.vue
+++ b/src/components/CategorizedStock.vue
@@ -38,7 +38,7 @@
       />
     </label>
     <p
-      v-show="!isCategorizing && isCancelingCategorizing"
+      v-show="!isCategorizing && isCancelingCategorization"
       class="times-circle"
       @click="onClickCancelCategorization"
     >
@@ -60,7 +60,7 @@ export default class CategorizedStock extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   onClickCheckStock() {
     this.$emit("clickCheckStock", this.stock);

--- a/src/components/CategorizedStock.vue
+++ b/src/components/CategorizedStock.vue
@@ -38,7 +38,7 @@
       />
     </label>
     <p
-      v-show="!isCategorizing"
+      v-show="!isCategorizing && isCancelingCategorizing"
       class="times-circle"
       @click="onClickCancelCategorization"
     >
@@ -58,6 +58,9 @@ export default class CategorizedStock extends Vue {
 
   @Prop()
   isCategorizing!: boolean;
+
+  @Prop()
+  isCancelingCategorizing!: boolean;
 
   onClickCheckStock() {
     this.$emit("clickCheckStock", this.stock);
@@ -100,7 +103,6 @@ a:hover {
 
 .times-circle {
   color: darkgray;
-  display: none;
   float: right;
   transition: color 0.2s ease-out;
   padding: 0.5rem;
@@ -108,9 +110,5 @@ a:hover {
 
 .times-circle:hover {
   color: gray;
-}
-
-article:hover .times-circle {
-  display: block;
 }
 </style>

--- a/src/components/CategorizedStockEdit.vue
+++ b/src/components/CategorizedStockEdit.vue
@@ -5,17 +5,17 @@
         <div v-if="!isCategorizing" class="cancel-categorization-margin">
           <button
             :class="
-              `button is-light button-margin ${isCancelingCategorizing &&
+              `button is-light button-margin ${isCancelingCategorization &&
                 'is-link'}`
             "
-            @click="setIsCancelingCategorizing"
+            @click="setIsCancelingCategorization"
           >
             カテゴライズを解除する
           </button>
         </div>
         <CategorizeButton
           :isCategorizing="isCategorizing"
-          :isCancelingCategorizing="isCancelingCategorizing"
+          :isCancelingCategorization="isCancelingCategorization"
           :displayCategories="displayCategories"
           :checkedStockArticleIds="checkedStockArticleIds"
           @clickSetIsCategorizing="onSetIsCategorizing"
@@ -47,7 +47,7 @@ export default class CategorizedStockEdit extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @Prop()
   displayCategories!: ICategory[];
@@ -55,8 +55,8 @@ export default class CategorizedStockEdit extends Vue {
   @Prop()
   checkedStockArticleIds!: string[];
 
-  setIsCancelingCategorizing() {
-    this.$emit("clickSetIsCancelingCategorizing");
+  setIsCancelingCategorization() {
+    this.$emit("clickSetIsCancelingCategorization");
   }
 
   onSetIsCategorizing() {

--- a/src/components/CategorizedStockEdit.vue
+++ b/src/components/CategorizedStockEdit.vue
@@ -1,0 +1,144 @@
+<template>
+  <div v-show="stocksLength && !isLoading">
+    <AlertModal
+      :isShow="showAlert"
+      :message="alertMessage"
+      @closeModal="closeModal"
+    />
+    <div class="navbar-menu edit-menu">
+      <div class="navbar-end">
+        <div v-if="!isCategorizing" class="cancel-categorization-margin">
+          <button
+            :class="
+              `button is-light button-margin ${isCancelingCategorizing &&
+                'is-link'}`
+            "
+            @click="setIsCancelingCategorizing"
+          >
+            カテゴライズを解除する
+          </button>
+        </div>
+        <div v-if="isCategorizing">
+          <div
+            :class="`select edit-header ${isValidationError && 'is-danger'}`"
+          >
+            <select
+              v-model="selectedCategory"
+              @change="isValidationError = false;"
+            >
+              <option
+                v-for="category in displayCategories"
+                :value="category"
+                :key="category.categoryId"
+                >{{ category.name }}</option
+              >
+            </select>
+          </div>
+          <button
+            class="button is-danger button-margin"
+            @click="changeCategory"
+          >
+            保存
+          </button>
+          <button
+            class="button is-white has-text-grey button-margin"
+            @click="cancel"
+          >
+            キャンセル
+          </button>
+        </div>
+        <div v-show="!isCancelingCategorizing" v-else>
+          <button class="button is-light button-margin" @click="startEdit">
+            カテゴリに分類する
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+import { ICategory } from "@/domain/qiita";
+import AlertModal from "@/components/AlertModal.vue";
+
+@Component({
+  components: {
+    AlertModal
+  }
+})
+export default class CategorizedStockEdit extends Vue {
+  @Prop()
+  isLoading!: boolean;
+
+  @Prop()
+  stocksLength!: number;
+
+  @Prop()
+  isCategorizing!: boolean;
+
+  @Prop()
+  isCancelingCategorizing!: boolean;
+
+  @Prop()
+  displayCategories!: ICategory[];
+
+  @Prop()
+  checkedStockArticleIds!: string[];
+
+  selectedCategory: ICategory = { categoryId: 0, name: "" };
+  isValidationError: boolean = false;
+  showAlert: boolean = false;
+  alertMessage: string = "ストックを1つ以上選択してください。";
+
+  doneEdit() {
+    this.isValidationError = false;
+    this.$emit("clickSetIsCategorizing");
+  }
+
+  startEdit() {
+    this.doneEdit();
+  }
+
+  cancel() {
+    this.doneEdit();
+  }
+
+  changeCategory() {
+    if (!this.selectedCategory.categoryId)
+      return (this.isValidationError = true);
+
+    if (!this.checkedStockArticleIds.length) return (this.showAlert = true);
+
+    this.$emit("clickCategorize", this.selectedCategory);
+    this.doneEdit();
+  }
+
+  setIsCancelingCategorizing() {
+    this.$emit("clickSetIsCancelingCategorizing");
+  }
+
+  closeModal() {
+    this.showAlert = false;
+  }
+}
+</script>
+
+<style scoped>
+.edit-header {
+  margin-right: 10px;
+}
+
+.edit-menu {
+  display: block;
+  box-shadow: none;
+}
+
+.cancel-categorization-margin {
+  margin-right: 0.5rem;
+}
+
+.button-margin {
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/src/components/CategorizedStockEdit.vue
+++ b/src/components/CategorizedStockEdit.vue
@@ -1,10 +1,5 @@
 <template>
   <div v-show="stocksLength && !isLoading">
-    <AlertModal
-      :isShow="showAlert"
-      :message="alertMessage"
-      @closeModal="closeModal"
-    />
     <div class="navbar-menu edit-menu">
       <div class="navbar-end">
         <div v-if="!isCategorizing" class="cancel-categorization-margin">
@@ -18,40 +13,14 @@
             カテゴライズを解除する
           </button>
         </div>
-        <div v-if="isCategorizing">
-          <div
-            :class="`select edit-header ${isValidationError && 'is-danger'}`"
-          >
-            <select
-              v-model="selectedCategory"
-              @change="isValidationError = false;"
-            >
-              <option
-                v-for="category in displayCategories"
-                :value="category"
-                :key="category.categoryId"
-                >{{ category.name }}</option
-              >
-            </select>
-          </div>
-          <button
-            class="button is-danger button-margin"
-            @click="changeCategory"
-          >
-            保存
-          </button>
-          <button
-            class="button is-white has-text-grey button-margin"
-            @click="cancel"
-          >
-            キャンセル
-          </button>
-        </div>
-        <div v-show="!isCancelingCategorizing" v-else>
-          <button class="button is-light button-margin" @click="startEdit">
-            カテゴリに分類する
-          </button>
-        </div>
+        <CategorizeButton
+          :isCategorizing="isCategorizing"
+          :isCancelingCategorizing="isCancelingCategorizing"
+          :displayCategories="displayCategories"
+          :checkedStockArticleIds="checkedStockArticleIds"
+          @clickSetIsCategorizing="onSetIsCategorizing"
+          @clickCategorize="onClickCategorize"
+        />
       </div>
     </div>
   </div>
@@ -60,11 +29,11 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
-import AlertModal from "@/components/AlertModal.vue";
+import CategorizeButton from "@/components/CategorizeButton.vue";
 
 @Component({
   components: {
-    AlertModal
+    CategorizeButton
   }
 })
 export default class CategorizedStockEdit extends Vue {
@@ -86,49 +55,21 @@ export default class CategorizedStockEdit extends Vue {
   @Prop()
   checkedStockArticleIds!: string[];
 
-  selectedCategory: ICategory = { categoryId: 0, name: "" };
-  isValidationError: boolean = false;
-  showAlert: boolean = false;
-  alertMessage: string = "ストックを1つ以上選択してください。";
-
-  doneEdit() {
-    this.isValidationError = false;
-    this.$emit("clickSetIsCategorizing");
-  }
-
-  startEdit() {
-    this.doneEdit();
-  }
-
-  cancel() {
-    this.doneEdit();
-  }
-
-  changeCategory() {
-    if (!this.selectedCategory.categoryId)
-      return (this.isValidationError = true);
-
-    if (!this.checkedStockArticleIds.length) return (this.showAlert = true);
-
-    this.$emit("clickCategorize", this.selectedCategory);
-    this.doneEdit();
-  }
-
   setIsCancelingCategorizing() {
     this.$emit("clickSetIsCancelingCategorizing");
   }
 
-  closeModal() {
-    this.showAlert = false;
+  onSetIsCategorizing() {
+    this.$emit("clickSetIsCategorizing");
+  }
+
+  onClickCategorize(category: ICategory) {
+    this.$emit("clickCategorize", category);
   }
 }
 </script>
 
 <style scoped>
-.edit-header {
-  margin-right: 10px;
-}
-
 .edit-menu {
   display: block;
   box-shadow: none;

--- a/src/components/CategorizedStockList.vue
+++ b/src/components/CategorizedStockList.vue
@@ -7,6 +7,7 @@
         :stock="stock"
         :key="stock.id"
         :isCategorizing="isCategorizing"
+        :isCancelingCategorizing="isCancelingCategorizing"
         @clickCheckStock="onClickCheckStock"
         @clickCancelCategorization="onClickCancelCategorization"
       />
@@ -31,6 +32,9 @@ export default class CategorizedStockList extends Vue {
 
   @Prop()
   isCategorizing!: boolean;
+
+  @Prop()
+  isCancelingCategorizing!: boolean;
 
   @Prop()
   isLoading!: boolean;

--- a/src/components/CategorizedStockList.vue
+++ b/src/components/CategorizedStockList.vue
@@ -7,7 +7,7 @@
         :stock="stock"
         :key="stock.id"
         :isCategorizing="isCategorizing"
-        :isCancelingCategorizing="isCancelingCategorizing"
+        :isCancelingCategorization="isCancelingCategorization"
         @clickCheckStock="onClickCheckStock"
         @clickCancelCategorization="onClickCancelCategorization"
       />
@@ -34,7 +34,7 @@ export default class CategorizedStockList extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @Prop()
   isLoading!: boolean;

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -4,7 +4,7 @@
       <div class="navbar-end">
         <CategorizeButton
           :isCategorizing="isCategorizing"
-          :isCancelingCategorizing="isCancelingCategorizing"
+          :isCancelingCategorization="isCancelingCategorization"
           :displayCategories="displayCategories"
           :checkedStockArticleIds="checkedStockArticleIds"
           @clickSetIsCategorizing="onSetIsCategorizing"
@@ -36,7 +36,7 @@ export default class StockEdit extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @Prop()
   displayCategories!: ICategory[];

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,38 +1,15 @@
 <template>
   <div v-show="stocksLength && !isLoading">
-    <AlertModal
-      :isShow="showAlert"
-      :message="alertMessage"
-      @closeModal="closeModal"
-    />
     <div class="navbar-menu edit-menu">
       <div class="navbar-end">
-        <div v-if="isCategorizing">
-          <div
-            :class="`select edit-header ${isValidationError && 'is-danger'}`"
-          >
-            <select
-              v-model="selectedCategory"
-              @change="isValidationError = false;"
-            >
-              <option
-                v-for="category in displayCategories"
-                :value="category"
-                :key="category.categoryId"
-                >{{ category.name }}</option
-              >
-            </select>
-          </div>
-          <button class="button is-danger" @click="changeCategory">保存</button>
-          <button class="button is-white has-text-grey" @click="cancel">
-            キャンセル
-          </button>
-        </div>
-        <div v-else>
-          <button class="button is-light" @click="startEdit">
-            カテゴリに分類する
-          </button>
-        </div>
+        <CategorizeButton
+          :isCategorizing="isCategorizing"
+          :isCancelingCategorizing="isCancelingCategorizing"
+          :displayCategories="displayCategories"
+          :checkedStockArticleIds="checkedStockArticleIds"
+          @clickSetIsCategorizing="onSetIsCategorizing"
+          @clickCategorize="onClickCategorize"
+        />
       </div>
     </div>
   </div>
@@ -41,11 +18,11 @@
 <script lang="ts">
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { ICategory } from "@/domain/qiita";
-import AlertModal from "@/components/AlertModal.vue";
+import CategorizeButton from "@/components/CategorizeButton.vue";
 
 @Component({
   components: {
-    AlertModal
+    CategorizeButton
   }
 })
 export default class StockEdit extends Vue {
@@ -59,52 +36,31 @@ export default class StockEdit extends Vue {
   isCategorizing!: boolean;
 
   @Prop()
+  isCancelingCategorizing!: boolean;
+
+  @Prop()
   displayCategories!: ICategory[];
 
   @Prop()
   checkedStockArticleIds!: string[];
 
-  selectedCategory: ICategory = { categoryId: 0, name: "" };
-  isValidationError: boolean = false;
-  showAlert: boolean = false;
-  alertMessage: string = "ストックを1つ以上選択してください。";
-
-  doneEdit() {
-    this.isValidationError = false;
+  onSetIsCategorizing() {
     this.$emit("clickSetIsCategorizing");
   }
 
-  startEdit() {
-    this.doneEdit();
-  }
-
-  cancel() {
-    this.doneEdit();
-  }
-
-  changeCategory() {
-    if (!this.selectedCategory.categoryId)
-      return (this.isValidationError = true);
-
-    if (!this.checkedStockArticleIds.length) return (this.showAlert = true);
-
-    this.$emit("clickCategorize", this.selectedCategory);
-    this.doneEdit();
-  }
-
-  closeModal() {
-    this.showAlert = false;
+  onClickCategorize(category: ICategory) {
+    this.$emit("clickCategorize", category);
   }
 }
 </script>
 
 <style scoped>
-.edit-header {
-  margin-right: 10px;
-}
-
 .edit-menu {
   display: block;
   box-shadow: none;
+}
+
+.button-margin {
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -21,7 +21,6 @@
             :stocksLength="categorizedStocks.length"
             :isCategorizing="isCategorizing"
             :isCancelingCategorizing="isCancelingCategorizing"
-            :categories="categories"
             :displayCategories="displayCategories"
             :checkedStockArticleIds="checkedCategorizedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -20,17 +20,17 @@
             :isLoading="isLoading"
             :stocksLength="categorizedStocks.length"
             :isCategorizing="isCategorizing"
-            :isCancelingCategorizing="isCancelingCategorizing"
+            :isCancelingCategorization="isCancelingCategorization"
             :displayCategories="displayCategories"
             :checkedStockArticleIds="checkedCategorizedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
-            @clickSetIsCancelingCategorizing="onSetIsCancelingCategorizing"
+            @clickSetIsCancelingCategorization="onSetIsCancelingCategorization"
             @clickCategorize="onClickCategorize"
           />
           <CategorizedStockList
             :stocks="categorizedStocks"
             :isCategorizing="isCategorizing"
-            :isCancelingCategorizing="isCancelingCategorizing"
+            :isCancelingCategorization="isCancelingCategorization"
             :isLoading="isLoading"
             @clickCheckStock="onClickCheckStock"
             @clickCancelCategorization="onClickCancelCategorization"
@@ -97,7 +97,7 @@ export default class StockCategories extends Vue {
   isCategorizing!: boolean;
 
   @QiitaGetter
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @QiitaGetter
   isLoading!: boolean;
@@ -144,7 +144,7 @@ export default class StockCategories extends Vue {
   setIsCategorizing!: () => void;
 
   @QiitaAction
-  setIsCancelingCategorizing!: () => void;
+  setIsCancelingCategorization!: () => void;
 
   @QiitaAction
   categorize!: (categorizePayload: ICategorizePayload) => void;
@@ -212,8 +212,8 @@ export default class StockCategories extends Vue {
     this.setIsCategorizing();
   }
 
-  onSetIsCancelingCategorizing() {
-    this.setIsCancelingCategorizing();
+  onSetIsCancelingCategorization() {
+    this.setIsCancelingCategorization();
   }
 
   onClickStocksAll() {

--- a/src/pages/StockCategories.vue
+++ b/src/pages/StockCategories.vue
@@ -16,19 +16,22 @@
         </div>
         <div class="column is-9 column-padding">
           <Loading :isLoading="isLoading" />
-          <StockEdit
+          <CategorizedStockEdit
             :isLoading="isLoading"
             :stocksLength="categorizedStocks.length"
             :isCategorizing="isCategorizing"
+            :isCancelingCategorizing="isCancelingCategorizing"
             :categories="categories"
             :displayCategories="displayCategories"
             :checkedStockArticleIds="checkedCategorizedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
+            @clickSetIsCancelingCategorizing="onSetIsCancelingCategorizing"
             @clickCategorize="onClickCategorize"
           />
           <CategorizedStockList
             :stocks="categorizedStocks"
             :isCategorizing="isCategorizing"
+            :isCancelingCategorizing="isCancelingCategorizing"
             :isLoading="isLoading"
             @clickCheckStock="onClickCheckStock"
             @clickCancelCategorization="onClickCancelCategorization"
@@ -57,7 +60,7 @@ import { Getter, Action, namespace } from "vuex-class";
 
 import AppHeader from "@/components/AppHeader.vue";
 import SideMenu from "@/components/SideMenu.vue";
-import StockEdit from "@/components/StockEdit.vue";
+import CategorizedStockEdit from "@/components/CategorizedStockEdit.vue";
 import CategorizedStockList from "@/components/CategorizedStockList.vue";
 import Pagination from "@/components/Pagination.vue";
 import Loading from "@/components/Loading.vue";
@@ -75,7 +78,7 @@ const QiitaGetter = namespace("QiitaModule", Getter);
   components: {
     AppHeader,
     SideMenu,
-    StockEdit,
+    CategorizedStockEdit,
     CategorizedStockList,
     Pagination,
     Loading
@@ -93,6 +96,9 @@ export default class StockCategories extends Vue {
 
   @QiitaGetter
   isCategorizing!: boolean;
+
+  @QiitaGetter
+  isCancelingCategorizing!: boolean;
 
   @QiitaGetter
   isLoading!: boolean;
@@ -137,6 +143,9 @@ export default class StockCategories extends Vue {
 
   @QiitaAction
   setIsCategorizing!: () => void;
+
+  @QiitaAction
+  setIsCancelingCategorizing!: () => void;
 
   @QiitaAction
   categorize!: (categorizePayload: ICategorizePayload) => void;
@@ -202,6 +211,10 @@ export default class StockCategories extends Vue {
 
   onSetIsCategorizing() {
     this.setIsCategorizing();
+  }
+
+  onSetIsCancelingCategorizing() {
+    this.setIsCancelingCategorizing();
   }
 
   onClickStocksAll() {

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -18,6 +18,7 @@
             :isLoading="isLoading"
             :stocksLength="stocks.length"
             :isCategorizing="isCategorizing"
+            :isCancelingCategorizing="isCancelingCategorizing"
             :displayCategories="displayCategories"
             :checkedStockArticleIds="checkedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
@@ -88,6 +89,9 @@ export default class Stocks extends Vue {
 
   @QiitaGetter
   isCategorizing!: boolean;
+
+  @QiitaGetter
+  isCancelingCategorizing!: boolean;
 
   @QiitaGetter
   isLoading!: boolean;

--- a/src/pages/Stocks.vue
+++ b/src/pages/Stocks.vue
@@ -18,7 +18,7 @@
             :isLoading="isLoading"
             :stocksLength="stocks.length"
             :isCategorizing="isCategorizing"
-            :isCancelingCategorizing="isCancelingCategorizing"
+            :isCancelingCategorization="isCancelingCategorization"
             :displayCategories="displayCategories"
             :checkedStockArticleIds="checkedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
@@ -91,7 +91,7 @@ export default class Stocks extends Vue {
   isCategorizing!: boolean;
 
   @QiitaGetter
-  isCancelingCategorizing!: boolean;
+  isCancelingCategorization!: boolean;
 
   @QiitaGetter
   isLoading!: boolean;

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -112,7 +112,7 @@ const state: IQiitaState = {
   paging: [],
   displayCategoryId: 0,
   isCategorizing: false,
-  isCancelingCategorizing: false,
+  isCancelingCategorization: false,
   isLoading: true
 };
 
@@ -149,8 +149,10 @@ const getters: GetterTree<IQiitaState, RootState> = {
   isCategorizing: (state): IQiitaState["isCategorizing"] => {
     return state.isCategorizing;
   },
-  isCancelingCategorizing: (state): IQiitaState["isCancelingCategorizing"] => {
-    return state.isCancelingCategorizing;
+  isCancelingCategorization: (
+    state
+  ): IQiitaState["isCancelingCategorization"] => {
+    return state.isCancelingCategorization;
   },
   isLoading: (state): IQiitaState["isLoading"] => {
     return state.isLoading;
@@ -300,12 +302,12 @@ const mutations: MutationTree<IQiitaState> = {
   setIsCategorizing: state => {
     state.isCategorizing = !state.isCategorizing;
   },
-  setIsCancelingCategorizing: state => {
-    state.isCancelingCategorizing = !state.isCancelingCategorizing;
+  setIsCancelingCategorization: state => {
+    state.isCancelingCategorization = !state.isCancelingCategorization;
   },
   resetData: state => {
     state.isCategorizing = false;
-    state.isCancelingCategorizing = false;
+    state.isCancelingCategorization = false;
     state.displayCategoryId = 0;
     state.currentPage = 1;
   },
@@ -756,8 +758,8 @@ const actions: ActionTree<IQiitaState, RootState> = {
   setIsCategorizing: async ({ commit }) => {
     commit("setIsCategorizing");
   },
-  setIsCancelingCategorizing: async ({ commit }) => {
-    commit("setIsCancelingCategorizing");
+  setIsCancelingCategorization: async ({ commit }) => {
+    commit("setIsCancelingCategorization");
   },
   categorize: async ({ commit }, categorizePayload: ICategorizePayload) => {
     try {

--- a/src/store/modules/qiita.ts
+++ b/src/store/modules/qiita.ts
@@ -112,6 +112,7 @@ const state: IQiitaState = {
   paging: [],
   displayCategoryId: 0,
   isCategorizing: false,
+  isCancelingCategorizing: false,
   isLoading: true
 };
 
@@ -147,6 +148,9 @@ const getters: GetterTree<IQiitaState, RootState> = {
   },
   isCategorizing: (state): IQiitaState["isCategorizing"] => {
     return state.isCategorizing;
+  },
+  isCancelingCategorizing: (state): IQiitaState["isCancelingCategorizing"] => {
+    return state.isCancelingCategorizing;
   },
   isLoading: (state): IQiitaState["isLoading"] => {
     return state.isLoading;
@@ -296,8 +300,14 @@ const mutations: MutationTree<IQiitaState> = {
   setIsCategorizing: state => {
     state.isCategorizing = !state.isCategorizing;
   },
-  restIsCategorizing: state => {
+  setIsCancelingCategorizing: state => {
+    state.isCancelingCategorizing = !state.isCancelingCategorizing;
+  },
+  resetData: state => {
     state.isCategorizing = false;
+    state.isCancelingCategorizing = false;
+    state.displayCategoryId = 0;
+    state.currentPage = 1;
   },
   setIsLoading: (state, isLoading: boolean) => {
     state.isLoading = isLoading;
@@ -746,6 +756,9 @@ const actions: ActionTree<IQiitaState, RootState> = {
   setIsCategorizing: async ({ commit }) => {
     commit("setIsCategorizing");
   },
+  setIsCancelingCategorizing: async ({ commit }) => {
+    commit("setIsCancelingCategorizing");
+  },
   categorize: async ({ commit }, categorizePayload: ICategorizePayload) => {
     try {
       const sessionId = localStorage.load(STORAGE_KEY_SESSION_ID);
@@ -807,9 +820,7 @@ const actions: ActionTree<IQiitaState, RootState> = {
     commit("checkCategorizedStock", { stock, isChecked: !stock.isChecked });
   },
   resetData: ({ commit }): void => {
-    commit("saveDisplayCategoryId", 0);
-    commit("restIsCategorizing");
-    commit("saveCurrentPage", 1);
+    commit("resetData");
     commit("saveStocks", []);
     commit("saveCategorizedStocks", []);
   },

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -18,6 +18,6 @@ export interface IQiitaState {
   paging: IPage[];
   displayCategoryId: number;
   isCategorizing: boolean;
-  isCancelingCategorizing: boolean;
+  isCancelingCategorization: boolean;
   isLoading: boolean;
 }

--- a/src/types/qiita.ts
+++ b/src/types/qiita.ts
@@ -18,5 +18,6 @@ export interface IQiitaState {
   paging: IPage[];
   displayCategoryId: number;
   isCategorizing: boolean;
+  isCancelingCategorizing: boolean;
   isLoading: boolean;
 }

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -31,7 +31,7 @@ describe("AppHeader.vue", () => {
     paging: [],
     displayCategoryId: 0,
     isCategorizing: false,
-    isCancelingCategorizing: false,
+    isCancelingCategorization: false,
     isLoading: false
   };
 

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -31,6 +31,7 @@ describe("AppHeader.vue", () => {
     paging: [],
     displayCategoryId: 0,
     isCategorizing: false,
+    isCancelingCategorizing: false,
     isLoading: false
   };
 

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -32,6 +32,7 @@ describe("Cancel.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
+      isCancelingCategorizing: false,
       isLoading: false
     };
 

--- a/tests/unit/Cancel.spec.ts
+++ b/tests/unit/Cancel.spec.ts
@@ -32,7 +32,7 @@ describe("Cancel.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
-      isCancelingCategorizing: false,
+      isCancelingCategorization: false,
       isLoading: false
     };
 

--- a/tests/unit/CategorizeButton.spec.ts
+++ b/tests/unit/CategorizeButton.spec.ts
@@ -1,0 +1,160 @@
+import { shallowMount } from "@vue/test-utils";
+import CategorizeButton from "@/components/CategorizeButton.vue";
+import { ICategory } from "@/domain/qiita";
+
+describe("CategorizeButton.vue", () => {
+  const propsData: {
+    isCategorizing: boolean;
+    isCancelingCategorizing: boolean;
+    displayCategories: ICategory[];
+    checkedStockArticleIds: string[];
+  } = {
+    isCategorizing: false,
+    isCancelingCategorizing: false,
+    displayCategories: [
+      { categoryId: 1, name: "テストカテゴリ1" },
+      { categoryId: 2, name: "テストカテゴリ2" }
+    ],
+    checkedStockArticleIds: ["aabbccddee0000000000"]
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(CategorizeButton, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickSetIsCategorizing on startEdit()", () => {
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.doneEdit();
+      expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
+    });
+
+    it("should call doneEdit on startEdit()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.startEdit();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should call doneEdit on cancel()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.cancel();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should emit clickCategorize on changeCategory()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+      const selectedCategory = propsData.displayCategories[0];
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = selectedCategory;
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(mock).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
+        selectedCategory
+      );
+    });
+
+    it("should not emit clickCategorize on changeCategory() when category is not selected", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
+    });
+
+    it("should not emit clickCategorize on changeCategory() when stock is not checked", () => {
+      propsData.checkedStockArticleIds = [];
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = propsData.displayCategories[0];
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call startEdit when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({
+        startEdit: mock
+      });
+
+      wrapper.find("button").trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call changeCategory when button is clicked", () => {
+      propsData.isCategorizing = true;
+      propsData.displayCategories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({
+        changeCategory: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(0)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call cancel when button is clicked", () => {
+      propsData.isCategorizing = true;
+      propsData.displayCategories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
+
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizeButton, { propsData });
+
+      wrapper.setMethods({
+        cancel: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/CategorizeButton.spec.ts
+++ b/tests/unit/CategorizeButton.spec.ts
@@ -5,12 +5,12 @@ import { ICategory } from "@/domain/qiita";
 describe("CategorizeButton.vue", () => {
   const propsData: {
     isCategorizing: boolean;
-    isCancelingCategorizing: boolean;
+    isCancelingCategorization: boolean;
     displayCategories: ICategory[];
     checkedStockArticleIds: string[];
   } = {
     isCategorizing: false,
-    isCancelingCategorizing: false,
+    isCancelingCategorization: false,
     displayCategories: [
       { categoryId: 1, name: "テストカテゴリ1" },
       { categoryId: 2, name: "テストカテゴリ2" }

--- a/tests/unit/CategorizedStock.spec.ts
+++ b/tests/unit/CategorizedStock.spec.ts
@@ -14,9 +14,14 @@ describe("CategorizedStock.vue", () => {
     isChecked: true
   };
 
-  const propsData: { stock: ICategorizedStock; isCategorizing: boolean } = {
+  const propsData: {
+    stock: ICategorizedStock;
+    isCategorizing: boolean;
+    isCancelingCategorizing: boolean;
+  } = {
     stock,
-    isCategorizing: false
+    isCategorizing: false,
+    isCancelingCategorizing: false
   };
 
   it("props", () => {

--- a/tests/unit/CategorizedStock.spec.ts
+++ b/tests/unit/CategorizedStock.spec.ts
@@ -17,11 +17,11 @@ describe("CategorizedStock.vue", () => {
   const propsData: {
     stock: ICategorizedStock;
     isCategorizing: boolean;
-    isCancelingCategorizing: boolean;
+    isCancelingCategorization: boolean;
   } = {
     stock,
     isCategorizing: false,
-    isCancelingCategorizing: false
+    isCancelingCategorization: false
   };
 
   it("props", () => {

--- a/tests/unit/CategorizedStockEdit.spec.ts
+++ b/tests/unit/CategorizedStockEdit.spec.ts
@@ -1,6 +1,9 @@
-import { shallowMount } from "@vue/test-utils";
+import { config, shallowMount, mount } from "@vue/test-utils";
 import CategorizedStockEdit from "@/components/CategorizedStockEdit.vue";
+import CategorizeButton from "@/components/CategorizeButton.vue";
 import { ICategory } from "@/domain/qiita";
+
+config.logModifiedComponents = false;
 
 describe("CategorizedStockEdit.vue", () => {
   const propsData: {
@@ -26,84 +29,6 @@ describe("CategorizedStockEdit.vue", () => {
   });
 
   describe("methods", () => {
-    it("should emit clickSetIsCategorizing on startEdit()", () => {
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      // @ts-ignore
-      wrapper.vm.doneEdit();
-      expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
-    });
-
-    it("should call doneEdit on startEdit()", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.startEdit();
-      expect(mock).toBeTruthy();
-    });
-
-    it("should call doneEdit on cancel()", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.cancel();
-      expect(mock).toBeTruthy();
-    });
-
-    it("should emit clickCategorize on changeCategory()", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-      const selectedCategory = propsData.displayCategories[0];
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = selectedCategory;
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(mock).toBeTruthy();
-      expect(wrapper.emitted("clickCategorize")).toBeTruthy();
-      expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
-        selectedCategory
-      );
-    });
-
-    it("should not emit clickCategorize on changeCategory() when category is not selected", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
-    });
-
-    it("should not emit clickCategorize on changeCategory() when stock is not checked", () => {
-      propsData.checkedStockArticleIds = [];
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = propsData.displayCategories[0];
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
-    });
-
     it("should emit clickSetIsCancelingCategorizing on setIsCancelingCategorizing()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(CategorizedStockEdit, { propsData });
@@ -114,63 +39,65 @@ describe("CategorizedStockEdit.vue", () => {
       wrapper.vm.setIsCancelingCategorizing();
       expect(wrapper.emitted("clickSetIsCancelingCategorizing")).toBeTruthy();
     });
+
+    it("should emit clickSetIsCategorizing on onSetIsCategorizing()", () => {
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onSetIsCategorizing();
+      expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
+    });
+
+    it("should emit clickCategorize on onClickCategorize()", () => {
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.onClickCategorize(propsData.displayCategories[0]);
+      expect(wrapper.emitted("clickCategorize")).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
+        propsData.displayCategories[0]
+      );
+    });
   });
 
   describe("template", () => {
-    it("should call startEdit when button is clicked", () => {
+    it("should call onSetIsCategorizing when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      wrapper.setMethods({
-        startEdit: mock
+      const wrapper = mount(CategorizedStockEdit, {
+        propsData
       });
 
-      wrapper
-        .findAll("button")
-        .at(1)
-        .trigger("click");
-      expect(mock).toHaveBeenCalled();
+      wrapper.setMethods({
+        onSetIsCategorizing: mock
+      });
+
+      const categorizeButton = wrapper.find(CategorizeButton);
+
+      // @ts-ignore
+      categorizeButton.vm.doneEdit();
+
+      expect(mock).toHaveBeenCalledWith();
     });
 
-    it("should call changeCategory when button is clicked", () => {
-      propsData.isCategorizing = true;
-      propsData.displayCategories = [
-        { categoryId: 1, name: "テストカテゴリ1" },
-        { categoryId: 2, name: "テストカテゴリ2" }
-      ];
+    it("should call onClickCategorize when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
-      wrapper.setMethods({
-        changeCategory: mock
+      const wrapper = mount(CategorizedStockEdit, {
+        propsData
       });
 
-      wrapper
-        .findAll("button")
-        .at(0)
-        .trigger("click");
-      expect(mock).toHaveBeenCalled();
-    });
-
-    it("should call cancel when button is clicked", () => {
-      propsData.isCategorizing = true;
-      propsData.displayCategories = [
-        { categoryId: 1, name: "テストカテゴリ1" },
-        { categoryId: 2, name: "テストカテゴリ2" }
-      ];
-
-      const mock = jest.fn();
-      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
-
       wrapper.setMethods({
-        cancel: mock
+        onClickCategorize: mock
       });
 
-      wrapper
-        .findAll("button")
-        .at(1)
-        .trigger("click");
-      expect(mock).toHaveBeenCalled();
+      const categorizeButton = wrapper.find(CategorizeButton);
+
+      // @ts-ignore
+      categorizeButton.vm.selectedCategory = propsData.displayCategories[0];
+
+      // @ts-ignore
+      categorizeButton.vm.changeCategory(categorizeButton.vm.selectedCategory);
+
+      expect(mock).toHaveBeenCalledWith(propsData.displayCategories[0]);
     });
 
     it("should call setIsCancelingCategorizing when button is clicked", () => {

--- a/tests/unit/CategorizedStockEdit.spec.ts
+++ b/tests/unit/CategorizedStockEdit.spec.ts
@@ -1,0 +1,217 @@
+import { shallowMount } from "@vue/test-utils";
+import CategorizedStockEdit from "@/components/CategorizedStockEdit.vue";
+import { ICategory } from "@/domain/qiita";
+
+describe("CategorizedStockEdit.vue", () => {
+  const propsData: {
+    isLoading: boolean;
+    stocksLength: number;
+    isCategorizing: boolean;
+    displayCategories: ICategory[];
+    checkedStockArticleIds: string[];
+  } = {
+    isLoading: false,
+    stocksLength: 10,
+    isCategorizing: false,
+    displayCategories: [
+      { categoryId: 1, name: "テストカテゴリ1" },
+      { categoryId: 2, name: "テストカテゴリ2" }
+    ],
+    checkedStockArticleIds: ["aabbccddee0000000000"]
+  };
+
+  it("props", () => {
+    const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+    expect(wrapper.props()).toEqual(propsData);
+  });
+
+  describe("methods", () => {
+    it("should emit clickSetIsCategorizing on startEdit()", () => {
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.doneEdit();
+      expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
+    });
+
+    it("should call doneEdit on startEdit()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.startEdit();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should call doneEdit on cancel()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.cancel();
+      expect(mock).toBeTruthy();
+    });
+
+    it("should emit clickCategorize on changeCategory()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+      const selectedCategory = propsData.displayCategories[0];
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = selectedCategory;
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(mock).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")).toBeTruthy();
+      expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
+        selectedCategory
+      );
+    });
+
+    it("should not emit clickCategorize on changeCategory() when category is not selected", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
+    });
+
+    it("should not emit clickCategorize on changeCategory() when stock is not checked", () => {
+      propsData.checkedStockArticleIds = [];
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      // @ts-ignore
+      wrapper.vm.selectedCategory = propsData.displayCategories[0];
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.changeCategory();
+      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
+    });
+
+    it("should emit clickSetIsCancelingCategorizing on setIsCancelingCategorizing()", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({ doneEdit: mock });
+
+      // @ts-ignore
+      wrapper.vm.setIsCancelingCategorizing();
+      expect(wrapper.emitted("clickSetIsCancelingCategorizing")).toBeTruthy();
+    });
+  });
+
+  describe("template", () => {
+    it("should call startEdit when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({
+        startEdit: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call changeCategory when button is clicked", () => {
+      propsData.isCategorizing = true;
+      propsData.displayCategories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({
+        changeCategory: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(0)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call cancel when button is clicked", () => {
+      propsData.isCategorizing = true;
+      propsData.displayCategories = [
+        { categoryId: 1, name: "テストカテゴリ1" },
+        { categoryId: 2, name: "テストカテゴリ2" }
+      ];
+
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({
+        cancel: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(1)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call setIsCancelingCategorizing when button is clicked", () => {
+      propsData.isCategorizing = false;
+      const mock = jest.fn();
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      wrapper.setMethods({
+        setIsCancelingCategorizing: mock
+      });
+
+      wrapper
+        .findAll("button")
+        .at(0)
+        .trigger("click");
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("renders navbar", () => {
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(true);
+    });
+
+    it("do not renders navbar when loading", () => {
+      propsData.isLoading = true;
+      propsData.stocksLength = 20;
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(false);
+    });
+
+    it("do not renders navbar when stocks length is 0", () => {
+      propsData.isLoading = false;
+      propsData.stocksLength = 0;
+      const wrapper = shallowMount(CategorizedStockEdit, { propsData });
+
+      const loadingMessage = wrapper.find("div");
+      expect(loadingMessage.isVisible()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/CategorizedStockEdit.spec.ts
+++ b/tests/unit/CategorizedStockEdit.spec.ts
@@ -29,15 +29,15 @@ describe("CategorizedStockEdit.vue", () => {
   });
 
   describe("methods", () => {
-    it("should emit clickSetIsCancelingCategorizing on setIsCancelingCategorizing()", () => {
+    it("should emit clickSetIsCancelingCategorization on setIsCancelingCategorization()", () => {
       const mock = jest.fn();
       const wrapper = shallowMount(CategorizedStockEdit, { propsData });
 
       wrapper.setMethods({ doneEdit: mock });
 
       // @ts-ignore
-      wrapper.vm.setIsCancelingCategorizing();
-      expect(wrapper.emitted("clickSetIsCancelingCategorizing")).toBeTruthy();
+      wrapper.vm.setIsCancelingCategorization();
+      expect(wrapper.emitted("clickSetIsCancelingCategorization")).toBeTruthy();
     });
 
     it("should emit clickSetIsCategorizing on onSetIsCategorizing()", () => {
@@ -100,13 +100,13 @@ describe("CategorizedStockEdit.vue", () => {
       expect(mock).toHaveBeenCalledWith(propsData.displayCategories[0]);
     });
 
-    it("should call setIsCancelingCategorizing when button is clicked", () => {
+    it("should call setIsCancelingCategorization when button is clicked", () => {
       propsData.isCategorizing = false;
       const mock = jest.fn();
       const wrapper = shallowMount(CategorizedStockEdit, { propsData });
 
       wrapper.setMethods({
-        setIsCancelingCategorizing: mock
+        setIsCancelingCategorization: mock
       });
 
       wrapper

--- a/tests/unit/CategorizedStockList.spec.ts
+++ b/tests/unit/CategorizedStockList.spec.ts
@@ -32,10 +32,12 @@ describe("CategorizedStockList.vue", () => {
   const propsData: {
     stocks: ICategorizedStock[];
     isCategorizing: boolean;
+    isCancelingCategorizing: boolean;
     isLoading: boolean;
   } = {
     stocks,
     isCategorizing: false,
+    isCancelingCategorizing: false,
     isLoading: false
   };
 

--- a/tests/unit/CategorizedStockList.spec.ts
+++ b/tests/unit/CategorizedStockList.spec.ts
@@ -32,12 +32,12 @@ describe("CategorizedStockList.vue", () => {
   const propsData: {
     stocks: ICategorizedStock[];
     isCategorizing: boolean;
-    isCancelingCategorizing: boolean;
+    isCancelingCategorization: boolean;
     isLoading: boolean;
   } = {
     stocks,
     isCategorizing: false,
-    isCancelingCategorizing: false,
+    isCancelingCategorization: false,
     isLoading: false
   };
 

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -32,7 +32,7 @@ describe("Login.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
-      isCancelingCategorizing: false,
+      isCancelingCategorization: false,
       isLoading: false
     };
 

--- a/tests/unit/Login.spec.ts
+++ b/tests/unit/Login.spec.ts
@@ -32,6 +32,7 @@ describe("Login.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
+      isCancelingCategorizing: false,
       isLoading: false
     };
 

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -111,7 +111,7 @@ describe("QiitaModule", () => {
         paging: [firstPage, prevPage, nextPage, lastPage],
         displayCategoryId: 2,
         isCategorizing: false,
-        isCancelingCategorizing: false,
+        isCancelingCategorization: false,
         isLoading: false
       };
     });
@@ -202,13 +202,16 @@ describe("QiitaModule", () => {
       expect(isCategorizing).toEqual(state.isCategorizing);
     });
 
-    it("should be able to get isCancelingCategorizing", () => {
-      const wrapper = (getters: any) => getters.isCancelingCategorizing(state);
-      const isCancelingCategorizing: IQiitaState["isCancelingCategorizing"] = wrapper(
+    it("should be able to get isCancelingCategorization", () => {
+      const wrapper = (getters: any) =>
+        getters.isCancelingCategorization(state);
+      const isCancelingCategorization: IQiitaState["isCancelingCategorization"] = wrapper(
         QiitaModule.getters
       );
 
-      expect(isCancelingCategorizing).toEqual(state.isCancelingCategorizing);
+      expect(isCancelingCategorization).toEqual(
+        state.isCancelingCategorization
+      );
     });
 
     it("should be able to get isLoading", () => {
@@ -292,7 +295,7 @@ describe("QiitaModule", () => {
         paging: [],
         displayCategoryId: 0,
         isCategorizing: false,
-        isCancelingCategorizing: false,
+        isCancelingCategorization: false,
         isLoading: false
       };
     });
@@ -705,18 +708,18 @@ describe("QiitaModule", () => {
       expect(state.isCategorizing).toEqual(true);
     });
 
-    it("should be able to save isCancelingCategorizing", () => {
+    it("should be able to save isCancelingCategorization", () => {
       const wrapper = (mutations: any) =>
-        mutations.setIsCancelingCategorizing(state);
+        mutations.setIsCancelingCategorization(state);
       wrapper(QiitaModule.mutations);
-      expect(state.isCancelingCategorizing).toEqual(true);
+      expect(state.isCancelingCategorization).toEqual(true);
     });
 
     it("should be able to reset data", () => {
       const wrapper = (mutations: any) => mutations.resetData(state);
       wrapper(QiitaModule.mutations);
       expect(state.isCategorizing).toEqual(false);
-      expect(state.isCancelingCategorizing).toEqual(false);
+      expect(state.isCancelingCategorization).toEqual(false);
       expect(state.displayCategoryId).toEqual(0);
       expect(state.currentPage).toEqual(1);
     });
@@ -1269,13 +1272,13 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([["setIsCategorizing"]]);
     });
 
-    it("should be able to set isCancelingCategorizing", async () => {
+    it("should be able to set isCancelingCategorization", async () => {
       const commit = jest.fn();
       const wrapper = (actions: any) =>
-        actions.setIsCancelingCategorizing({ commit });
+        actions.setIsCancelingCategorization({ commit });
       await wrapper(QiitaModule.actions);
 
-      expect(commit.mock.calls).toEqual([["setIsCancelingCategorizing"]]);
+      expect(commit.mock.calls).toEqual([["setIsCancelingCategorization"]]);
     });
 
     it("should be able to categorize", async () => {

--- a/tests/unit/QiitaModule.spec.ts
+++ b/tests/unit/QiitaModule.spec.ts
@@ -111,6 +111,7 @@ describe("QiitaModule", () => {
         paging: [firstPage, prevPage, nextPage, lastPage],
         displayCategoryId: 2,
         isCategorizing: false,
+        isCancelingCategorizing: false,
         isLoading: false
       };
     });
@@ -201,6 +202,15 @@ describe("QiitaModule", () => {
       expect(isCategorizing).toEqual(state.isCategorizing);
     });
 
+    it("should be able to get isCancelingCategorizing", () => {
+      const wrapper = (getters: any) => getters.isCancelingCategorizing(state);
+      const isCancelingCategorizing: IQiitaState["isCancelingCategorizing"] = wrapper(
+        QiitaModule.getters
+      );
+
+      expect(isCancelingCategorizing).toEqual(state.isCancelingCategorizing);
+    });
+
     it("should be able to get isLoading", () => {
       const wrapper = (getters: any) => getters.isLoading(state);
       const isLoading: IQiitaState["isLoading"] = wrapper(QiitaModule.getters);
@@ -282,6 +292,7 @@ describe("QiitaModule", () => {
         paging: [],
         displayCategoryId: 0,
         isCategorizing: false,
+        isCancelingCategorizing: false,
         isLoading: false
       };
     });
@@ -694,10 +705,20 @@ describe("QiitaModule", () => {
       expect(state.isCategorizing).toEqual(true);
     });
 
-    it("should be able to reset isCategorizing", () => {
-      const wrapper = (mutations: any) => mutations.restIsCategorizing(state);
+    it("should be able to save isCancelingCategorizing", () => {
+      const wrapper = (mutations: any) =>
+        mutations.setIsCancelingCategorizing(state);
+      wrapper(QiitaModule.mutations);
+      expect(state.isCancelingCategorizing).toEqual(true);
+    });
+
+    it("should be able to reset data", () => {
+      const wrapper = (mutations: any) => mutations.resetData(state);
       wrapper(QiitaModule.mutations);
       expect(state.isCategorizing).toEqual(false);
+      expect(state.isCancelingCategorizing).toEqual(false);
+      expect(state.displayCategoryId).toEqual(0);
+      expect(state.currentPage).toEqual(1);
     });
 
     it("should be able to save isLoading", () => {
@@ -1248,6 +1269,15 @@ describe("QiitaModule", () => {
       expect(commit.mock.calls).toEqual([["setIsCategorizing"]]);
     });
 
+    it("should be able to set isCancelingCategorizing", async () => {
+      const commit = jest.fn();
+      const wrapper = (actions: any) =>
+        actions.setIsCancelingCategorizing({ commit });
+      await wrapper(QiitaModule.actions);
+
+      expect(commit.mock.calls).toEqual([["setIsCancelingCategorizing"]]);
+    });
+
     it("should be able to categorize", async () => {
       const categorizePayload: ICategorizePayload = {
         category: { categoryId: 1, name: "category" },
@@ -1335,9 +1365,7 @@ describe("QiitaModule", () => {
       await wrapper(QiitaModule.actions);
 
       expect(commit.mock.calls).toEqual([
-        ["saveDisplayCategoryId", 0],
-        ["restIsCategorizing"],
-        ["saveCurrentPage", 1],
+        ["resetData"],
         ["saveStocks", []],
         ["saveCategorizedStocks", []]
       ]);

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -32,6 +32,7 @@ describe("SignUp.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
+      isCancelingCategorizing: false,
       isLoading: false
     };
 

--- a/tests/unit/SignUp.spec.ts
+++ b/tests/unit/SignUp.spec.ts
@@ -32,7 +32,7 @@ describe("SignUp.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
-      isCancelingCategorizing: false,
+      isCancelingCategorization: false,
       isLoading: false
     };
 

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -449,12 +449,7 @@ describe("StockCategories.vue", () => {
       const categorizedStockEdit = wrapper.find(CategorizedStockEdit);
 
       // @ts-ignore
-      categorizedStockEdit.vm.selectedCategory = {
-        categoryId: 1,
-        name: "category"
-      };
-      // @ts-ignore
-      categorizedStockEdit.vm.changeCategory();
+      categorizedStockEdit.vm.onSetIsCategorizing();
 
       expect(mock).toHaveBeenCalled();
     });
@@ -484,12 +479,10 @@ describe("StockCategories.vue", () => {
         onClickCategorize: mock
       });
 
-      const stockEdit = wrapper.find(CategorizedStockEdit);
+      const categorizedStockEdit = wrapper.find(CategorizedStockEdit);
 
       // @ts-ignore
-      stockEdit.vm.selectedCategory = category;
-      // @ts-ignore
-      stockEdit.vm.changeCategory();
+      categorizedStockEdit.vm.onClickCategorize(category);
 
       expect(mock).toHaveBeenCalledWith(category);
     });

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -71,7 +71,7 @@ describe("StockCategories.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
-      isCancelingCategorizing: false,
+      isCancelingCategorization: false,
       isLoading: false
     };
 
@@ -81,7 +81,7 @@ describe("StockCategories.vue", () => {
       fetchCategory: jest.fn(),
       fetchCategorizedStock: jest.fn(),
       setIsCategorizing: jest.fn(),
-      setIsCancelingCategorizing: jest.fn(),
+      setIsCancelingCategorization: jest.fn(),
       categorize: jest.fn(),
       checkCategorizedStock: jest.fn(),
       resetData: jest.fn(),
@@ -287,7 +287,7 @@ describe("StockCategories.vue", () => {
       expect(actions.setIsCategorizing).toHaveBeenCalled();
     });
 
-    it('calls store action "setIsCancelingCategorizing" on onSetIsCancelingCategorizing()', () => {
+    it('calls store action "setIsCancelingCategorization" on onSetIsCancelingCategorization()', () => {
       const wrapper = shallowMount(StockCategories, {
         store,
         localVue,
@@ -295,9 +295,9 @@ describe("StockCategories.vue", () => {
       });
 
       // @ts-ignore
-      wrapper.vm.onSetIsCancelingCategorizing();
+      wrapper.vm.onSetIsCancelingCategorization();
 
-      expect(actions.setIsCancelingCategorizing).toHaveBeenCalled();
+      expect(actions.setIsCancelingCategorization).toHaveBeenCalled();
     });
 
     it('calls store action "resetData" on onClickStocksAll()', () => {
@@ -454,18 +454,18 @@ describe("StockCategories.vue", () => {
       expect(mock).toHaveBeenCalled();
     });
 
-    it("should call onSetIsCancelingCategorizing when button is clicked", () => {
+    it("should call onSetIsCancelingCategorization when button is clicked", () => {
       const mock = jest.fn();
       const wrapper = mount(StockCategories, { store, localVue, router });
 
       wrapper.setMethods({
-        onSetIsCancelingCategorizing: mock
+        onSetIsCancelingCategorization: mock
       });
 
       const categorizedStockEdit = wrapper.find(CategorizedStockEdit);
 
       // @ts-ignore
-      categorizedStockEdit.vm.setIsCancelingCategorizing();
+      categorizedStockEdit.vm.setIsCancelingCategorization();
 
       expect(mock).toHaveBeenCalled();
     });

--- a/tests/unit/StockCategories.spec.ts
+++ b/tests/unit/StockCategories.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@/store/modules/qiita";
 import StockCategories from "@/pages/StockCategories.vue";
 import SideMenu from "@/components/SideMenu.vue";
-import StockEdit from "@/components/StockEdit.vue";
+import CategorizedStockEdit from "@/components/CategorizedStockEdit.vue";
 import CategorizedStockList from "@/components/CategorizedStockList.vue";
 import CategoryList from "@/components/CategoryList.vue";
 import Pagination from "@/components/Pagination.vue";
@@ -71,6 +71,7 @@ describe("StockCategories.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
+      isCancelingCategorizing: false,
       isLoading: false
     };
 
@@ -80,6 +81,7 @@ describe("StockCategories.vue", () => {
       fetchCategory: jest.fn(),
       fetchCategorizedStock: jest.fn(),
       setIsCategorizing: jest.fn(),
+      setIsCancelingCategorizing: jest.fn(),
       categorize: jest.fn(),
       checkCategorizedStock: jest.fn(),
       resetData: jest.fn(),
@@ -285,6 +287,19 @@ describe("StockCategories.vue", () => {
       expect(actions.setIsCategorizing).toHaveBeenCalled();
     });
 
+    it('calls store action "setIsCancelingCategorizing" on onSetIsCancelingCategorizing()', () => {
+      const wrapper = shallowMount(StockCategories, {
+        store,
+        localVue,
+        router
+      });
+
+      // @ts-ignore
+      wrapper.vm.onSetIsCancelingCategorizing();
+
+      expect(actions.setIsCancelingCategorizing).toHaveBeenCalled();
+    });
+
     it('calls store action "resetData" on onClickStocksAll()', () => {
       const wrapper = shallowMount(StockCategories, {
         store,
@@ -431,12 +446,31 @@ describe("StockCategories.vue", () => {
         onSetIsCategorizing: mock
       });
 
-      const stockEdit = wrapper.find(StockEdit);
+      const categorizedStockEdit = wrapper.find(CategorizedStockEdit);
 
       // @ts-ignore
-      stockEdit.vm.selectedCategory = { categoryId: 1, name: "category" };
+      categorizedStockEdit.vm.selectedCategory = {
+        categoryId: 1,
+        name: "category"
+      };
       // @ts-ignore
-      stockEdit.vm.changeCategory();
+      categorizedStockEdit.vm.changeCategory();
+
+      expect(mock).toHaveBeenCalled();
+    });
+
+    it("should call onSetIsCancelingCategorizing when button is clicked", () => {
+      const mock = jest.fn();
+      const wrapper = mount(StockCategories, { store, localVue, router });
+
+      wrapper.setMethods({
+        onSetIsCancelingCategorizing: mock
+      });
+
+      const categorizedStockEdit = wrapper.find(CategorizedStockEdit);
+
+      // @ts-ignore
+      categorizedStockEdit.vm.setIsCancelingCategorizing();
 
       expect(mock).toHaveBeenCalled();
     });
@@ -450,7 +484,7 @@ describe("StockCategories.vue", () => {
         onClickCategorize: mock
       });
 
-      const stockEdit = wrapper.find(StockEdit);
+      const stockEdit = wrapper.find(CategorizedStockEdit);
 
       // @ts-ignore
       stockEdit.vm.selectedCategory = category;

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -10,14 +10,14 @@ describe("StockEdit.vue", () => {
     isLoading: boolean;
     stocksLength: number;
     isCategorizing: boolean;
-    isCancelingCategorizing: boolean;
+    isCancelingCategorization: boolean;
     displayCategories: ICategory[];
     checkedStockArticleIds: string[];
   } = {
     isLoading: false,
     stocksLength: 10,
     isCategorizing: false,
-    isCancelingCategorizing: false,
+    isCancelingCategorization: false,
     displayCategories: [
       { categoryId: 1, name: "テストカテゴリ1" },
       { categoryId: 2, name: "テストカテゴリ2" }

--- a/tests/unit/StockEdit.spec.ts
+++ b/tests/unit/StockEdit.spec.ts
@@ -1,18 +1,23 @@
-import { shallowMount } from "@vue/test-utils";
+import { config, shallowMount, mount } from "@vue/test-utils";
 import StockEdit from "@/components/StockEdit.vue";
+import CategorizeButton from "@/components/CategorizeButton.vue";
 import { ICategory } from "@/domain/qiita";
+
+config.logModifiedComponents = false;
 
 describe("StockEdit.vue", () => {
   const propsData: {
     isLoading: boolean;
     stocksLength: number;
     isCategorizing: boolean;
+    isCancelingCategorizing: boolean;
     displayCategories: ICategory[];
     checkedStockArticleIds: string[];
   } = {
     isLoading: false,
     stocksLength: 10,
     isCategorizing: false,
+    isCancelingCategorizing: false,
     displayCategories: [
       { categoryId: 1, name: "テストカテゴリ1" },
       { categoryId: 2, name: "テストカテゴリ2" }
@@ -26,137 +31,64 @@ describe("StockEdit.vue", () => {
   });
 
   describe("methods", () => {
-    it("should emit clickSetIsCategorizing on startEdit()", () => {
+    it("should emit clickSetIsCategorizing on onSetIsCategorizing()", () => {
       const wrapper = shallowMount(StockEdit, { propsData });
 
       // @ts-ignore
-      wrapper.vm.doneEdit();
+      wrapper.vm.onSetIsCategorizing();
       expect(wrapper.emitted("clickSetIsCategorizing")).toBeTruthy();
     });
 
-    it("should call doneEdit on startEdit()", () => {
-      const mock = jest.fn();
+    it("should emit clickCategorize on onClickCategorize()", () => {
       const wrapper = shallowMount(StockEdit, { propsData });
 
-      wrapper.setMethods({ doneEdit: mock });
-
       // @ts-ignore
-      wrapper.vm.startEdit();
-      expect(mock).toBeTruthy();
-    });
-
-    it("should call doneEdit on cancel()", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.cancel();
-      expect(mock).toBeTruthy();
-    });
-
-    it("should emit clickCategorize on changeCategory()", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-      const selectedCategory = propsData.displayCategories[0];
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = selectedCategory;
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(mock).toBeTruthy();
+      wrapper.vm.onClickCategorize(propsData.displayCategories[0]);
       expect(wrapper.emitted("clickCategorize")).toBeTruthy();
       expect(wrapper.emitted("clickCategorize")[0][0]).toEqual(
-        selectedCategory
+        propsData.displayCategories[0]
       );
-    });
-
-    it("should not emit clickCategorize on changeCategory() when category is not selected", () => {
-      const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = { categoryId: 0, name: "" };
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
-    });
-
-    it("should not emit clickCategorize on changeCategory() when stock is not checked", () => {
-      propsData.checkedStockArticleIds = [];
-      const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
-      // @ts-ignore
-      wrapper.vm.selectedCategory = propsData.displayCategories[0];
-
-      wrapper.setMethods({ doneEdit: mock });
-
-      // @ts-ignore
-      wrapper.vm.changeCategory();
-      expect(wrapper.emitted("clickCategorize")).toBeFalsy();
     });
   });
 
   describe("template", () => {
-    it("should call startEdit when button is clicked", () => {
+    it("should call onSetIsCategorizing when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
-      wrapper.setMethods({
-        startEdit: mock
+      const wrapper = mount(StockEdit, {
+        propsData
       });
 
-      wrapper.find("button").trigger("click");
-      expect(mock).toHaveBeenCalled();
+      wrapper.setMethods({
+        onSetIsCategorizing: mock
+      });
+
+      const categorizeButton = wrapper.find(CategorizeButton);
+
+      // @ts-ignore
+      categorizeButton.vm.doneEdit();
+
+      expect(mock).toHaveBeenCalledWith();
     });
 
-    it("should call changeCategory when button is clicked", () => {
-      propsData.isCategorizing = true;
-      propsData.displayCategories = [
-        { categoryId: 1, name: "テストカテゴリ1" },
-        { categoryId: 2, name: "テストカテゴリ2" }
-      ];
+    it("should call onClickCategorize when button is clicked", () => {
       const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
-      wrapper.setMethods({
-        changeCategory: mock
+      const wrapper = mount(StockEdit, {
+        propsData
       });
 
-      wrapper
-        .findAll("button")
-        .at(0)
-        .trigger("click");
-      expect(mock).toHaveBeenCalled();
-    });
-
-    it("should call cancel when button is clicked", () => {
-      propsData.isCategorizing = true;
-      propsData.displayCategories = [
-        { categoryId: 1, name: "テストカテゴリ1" },
-        { categoryId: 2, name: "テストカテゴリ2" }
-      ];
-
-      const mock = jest.fn();
-      const wrapper = shallowMount(StockEdit, { propsData });
-
       wrapper.setMethods({
-        cancel: mock
+        onClickCategorize: mock
       });
 
-      wrapper
-        .findAll("button")
-        .at(1)
-        .trigger("click");
-      expect(mock).toHaveBeenCalled();
+      const categorizeButton = wrapper.find(CategorizeButton);
+
+      // @ts-ignore
+      categorizeButton.vm.selectedCategory = propsData.displayCategories[0];
+
+      // @ts-ignore
+      categorizeButton.vm.changeCategory(categorizeButton.vm.selectedCategory);
+
+      expect(mock).toHaveBeenCalledWith(propsData.displayCategories[0]);
     });
 
     it("renders navbar", () => {

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -301,9 +301,7 @@ describe("Stocks.vue", () => {
       const stockEdit = wrapper.find(StockEdit);
 
       // @ts-ignore
-      stockEdit.vm.selectedCategory = { categoryId: 1, name: "category" };
-      // @ts-ignore
-      stockEdit.vm.changeCategory();
+      stockEdit.vm.onSetIsCategorizing();
 
       expect(mock).toHaveBeenCalled();
     });
@@ -320,9 +318,7 @@ describe("Stocks.vue", () => {
       const category = { categoryId: 1, name: "category" };
 
       // @ts-ignore
-      stockEdit.vm.selectedCategory = category;
-      // @ts-ignore
-      stockEdit.vm.changeCategory();
+      stockEdit.vm.onClickCategorize(category);
 
       expect(mock).toHaveBeenCalledWith(category);
     });

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -64,7 +64,7 @@ describe("Stocks.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
-      isCancelingCategorizing: false,
+      isCancelingCategorization: false,
       isLoading: false
     };
 

--- a/tests/unit/Stocks.spec.ts
+++ b/tests/unit/Stocks.spec.ts
@@ -64,6 +64,7 @@ describe("Stocks.vue", () => {
       paging: [],
       displayCategoryId: 0,
       isCategorizing: false,
+      isCancelingCategorizing: false,
       isLoading: false
     };
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/195

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/195 の完了の条件が満たされていること

# スクリーンショット
カテゴリを選択した場合に「カテゴライズを解除する」ボタンを表示
<img width="921" alt="2019-01-30 18 36 59" src="https://user-images.githubusercontent.com/32682645/51972206-40bc9e00-24be-11e9-95a5-3e5d8ff11c20.png">

「カテゴライズを解除する」ボタンを押下すると×ボタンが表示される
<img width="884" alt="2019-01-30 18 37 22" src="https://user-images.githubusercontent.com/32682645/51972213-42866180-24be-11e9-934e-7d330e070ac5.png">

# 変更点概要

## 仕様的変更点概要
「カテゴライズを解除する」ボタンを追加。

## 技術的変更点概要
カテゴライズを解除中であるかどうかを判定するため、Stateに`isCancelingCategorization`を追加。

コンポーネントを下記の通り作成。
CategorizedStockEdit.vue：「カテゴライズを解除する」ボタンを表示するコンポーネント
StockEdit.vue：「カテゴライズを解除する」ボタンを表示しないコンポーネント

元々、`StockEdit.vue`に作成していた「カテゴリを分類する」ボタンについては、新規で作成した`CategorizeButton.vue`に処理を移動した。

また、今回のIssueとは関係ないが、OGPのURLの設定が反映されていなかったので修正。


# 補足
ステージング環境にデプロイ済み。
