### PR TITLE
デプロイスクリプトで index.prod.html, index.stg.html をアップロードしないように対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
+    "remove:htmlTemplate": "rm -rf dist/index.stg.html && rm -rf dist/index.prod.html",
     "generateDotenv:local": "DEPLOY_STAGE=local node generateEnv.js",
     "generateDotenv:dev": "DEPLOY_STAGE=dev node generateEnv.js",
     "generateDotenv:stg": "DEPLOY_STAGE=stg node generateEnv.js",
     "generateDotenv:prod": "DEPLOY_STAGE=prod node generateEnv.js",
-    "deploy:dev": "cp public/index.stg.html public/index.html  && rm -rf dist && yarn run generateDotenv:dev && yarn run build && DEPLOY_STAGE=dev node deployToS3.js",
-    "deploy:stg": "cp public/index.stg.html public/index.html  && rm -rf dist && yarn run generateDotenv:stg && yarn run build && DEPLOY_STAGE=stg node deployToS3.js",
-    "deploy:prod": "cp public/index.prod.html public/index.html  && rm -rf dist && yarn run generateDotenv:prod && yarn run build && DEPLOY_STAGE=prod node deployToS3.js"
+    "deploy:dev": "cp public/index.stg.html public/index.html && rm -rf dist && yarn run generateDotenv:dev && yarn run build && yarn run remove:htmlTemplate && DEPLOY_STAGE=dev node deployToS3.js",
+    "deploy:stg": "cp public/index.stg.html public/index.html && rm -rf dist && yarn run generateDotenv:stg && yarn run build && yarn run remove:htmlTemplate && DEPLOY_STAGE=stg node deployToS3.js",
+    "deploy:prod": "cp public/index.prod.html public/index.html && rm -rf dist && yarn run generateDotenv:prod && yarn run build && yarn run remove:htmlTemplate && DEPLOY_STAGE=prod node deployToS3.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.3",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/194

# Doneの定義
- https://github.com/nekochans/qiita-stocker-frontend/issues/194 の完了条件を満たしていること

# 変更点概要

## 技術的変更点概要
`remove:htmlTemplate` を `npm` に定義してdist配下からindex.htmlのファイルが消えるように調整。