### PR TITLE
Circle CI 上でnot enough memoryが起こる現象を修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,4 +22,4 @@ jobs:
     steps:
       - checkout
       - yarn_install
-      - run: yarn run test:unit
+      - run: yarn run test:unit:ci

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
+    "test:unit:ci": "vue-cli-service test:unit --runInBand",
     "remove:htmlTemplate": "rm -rf dist/index.stg.html && rm -rf dist/index.prod.html",
     "generateDotenv:local": "DEPLOY_STAGE=local node generateEnv.js",
     "generateDotenv:dev": "DEPLOY_STAGE=dev node generateEnv.js",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/219

# Doneの定義
- Circle CI 上でBuildが成功していること

# スクリーンショット
![successbuild](https://user-images.githubusercontent.com/11032365/53683030-7e237e00-3d3f-11e9-951f-57212f0b9be4.png)

# 変更点概要

## 技術的変更点概要
新しくnpm scriptに `test:unit:ci` を定義しその中で `--runInBand` オプションを有効にしてCircleCIではそれを実行するように変更。

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 `test:unit` を書き換えるという手もあったけど、ローカルとかメモリに余裕がある場合はマルチプロセスでテストが走ったほうが効率良いと思ったのと、CircleCIに課金すればメモリ不足は解消出来るけどこの為だけに課金はちょっともったいないと思ったから、バランスを取ってこうしているよ🐱！