### PR TITLE
カテゴライズボタンを画面下部に追加する

### DIFF
--- a/src/components/CategorizedStockEdit.vue
+++ b/src/components/CategorizedStockEdit.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-show="stocksLength && !isLoading">
+  <div
+    v-show="stocksLength && !isLoading"
+    :class="`${isSticky && 'stock-edit-sticky'}`"
+  >
     <div class="navbar-menu edit-menu">
       <div class="navbar-end">
         <div v-if="!isCategorizing" class="cancel-categorization-margin">
@@ -55,6 +58,10 @@ export default class CategorizedStockEdit extends Vue {
   @Prop()
   checkedStockArticleIds!: string[];
 
+  get isSticky(): boolean {
+    return this.isCategorizing || this.isCancelingCategorization;
+  }
+
   setIsCancelingCategorization() {
     this.$emit("clickSetIsCancelingCategorization");
   }
@@ -81,5 +88,15 @@ export default class CategorizedStockEdit extends Vue {
 
 .button-margin {
   margin-bottom: 0.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .stock-edit-sticky {
+    border-bottom: 1px solid #e8e8e8;
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
 }
 </style>

--- a/src/components/StockEdit.vue
+++ b/src/components/StockEdit.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-show="stocksLength && !isLoading">
+  <div
+    v-show="stocksLength && !isLoading"
+    :class="`${isCategorizing && 'stock-edit-sticky'}`"
+  >
     <div class="navbar-menu edit-menu">
       <div class="navbar-end">
         <CategorizeButton
@@ -60,7 +63,13 @@ export default class StockEdit extends Vue {
   box-shadow: none;
 }
 
-.button-margin {
-  margin-bottom: 0.5rem;
+@media screen and (max-width: 768px) {
+  .stock-edit-sticky {
+    border-bottom: 1px solid #e8e8e8;
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
 }
 </style>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/215

# Doneの定義
https://github.com/nekochans/qiita-stocker-frontend/issues/215 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
モバイルでの表示において、カテゴリに分類中、カテゴライズを解除中の場合のみ、ボタンが画面上部に固定されるように修正。なお、モバイル以外の表示では、今まで通りの動作となっている。
当初は、画面下部にカテゴライズボタンを追加する予定であったが、操作性を考慮し、ボタンの追加ではなく表示方法を変更する形で対応した。

- カテゴリに分類中
<img width="345" alt="スクリーンショット 2019-03-15 18 01 01" src="https://user-images.githubusercontent.com/32682645/54420036-51fafa80-474c-11e9-9a41-d9721acbb9e0.png">

- カテゴライズを解除中
<img width="343" alt="スクリーンショット 2019-03-15 18 01 28" src="https://user-images.githubusercontent.com/32682645/54420141-8c649780-474c-11e9-81c7-bc090b96e02b.png">

## 技術的変更点概要
[BLUMAのResponsiveness](https://bulma.io/documentation/overview/responsiveness/#breakpoints)に記載されているbreakpointsを元に、モバイル表示の場合のみスタイルに`position: sticky;`を追加し、ボタンを画面上部に固定している。

## 補足
[ブラウザの対応状況](https://developer.mozilla.org/ja/docs/Web/CSS/position#Browser_compatibility)