### PR TITLE
トップページの背景画像の色を調整する

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -2,7 +2,7 @@
   <div>
     <AppHeader />
     <section class="hero is-medium hero-top">
-      <div class="hero-body">
+      <div class="hero-body hero-filter">
         <div class="container">
           <div class="columns">
             <div class="column is-7">
@@ -78,8 +78,21 @@ export default class Home extends Vue {}
 
 <style scoped>
 .hero-top {
-  background: black url(../assets/top.jpg) center / cover;
+  background: black url(../assets/top.jpg) 62% 50% / cover;
 }
+
+@media screen and (max-width: 1024px) {
+  .hero-filter {
+    background-color: rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .hero-filter {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+}
+
 .subtitle {
   padding-top: 1rem;
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/217

# Doneの定義
モバイルでもトップページの文字が見やすいように背景画像の色が調整されていること

# スクリーンショット
- モバイル
<img width="353" alt="スクリーンショット 2019-03-16 1 52 24" src="https://user-images.githubusercontent.com/32682645/54448129-57793480-478e-11e9-8b39-fc73dfec573a.png">

- タブレット
<img width="1061" alt="スクリーンショット 2019-03-16 1 52 37" src="https://user-images.githubusercontent.com/32682645/54448172-737cd600-478e-11e9-84b4-b1b9b3da946d.png">

- PC (変更無し)
<img width="1440" alt="スクリーンショット 2019-03-16 1 45 04" src="https://user-images.githubusercontent.com/32682645/54448188-78da2080-478e-11e9-8a4b-3f00033520bc.png">

# 変更点概要

## 仕様的変更点概要
モバイルとタブレットの場合、背景画像に黒のフィルタをかけて白文字が見やすくなるように修正。
また、画像の位置を修正し、モバイルの場合も猫が見切れないように修正した。

## 技術的変更点概要
HOMEページのスタイルを修正。