### PR TITLE
ログイン判定に使っているCookieの有効期限を延長

### DIFF
--- a/server/auth/oauth.ts
+++ b/server/auth/oauth.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express'
 import * as auth from '../domain/auth'
+import { stage } from '../constants/envConstant'
 
 const router = Router()
 
@@ -61,10 +62,11 @@ router.get('/callback', async (req: Request, res: Response) => {
     )
     res.clearCookie(auth.COOKIE_AUTH_STATE)
     res.clearCookie(auth.COOKIE_ACCOUNT_ACTION)
-    res.cookie(auth.COOKIE_SESSION_ID, sessionId, {
-      path: '/',
-      httpOnly: true
-    })
+
+    const isLocal = stage() === 'local'
+    const cookieOptions = auth.loginSessionCookieOptions(isLocal)
+
+    res.cookie(auth.COOKIE_SESSION_ID, sessionId, cookieOptions)
 
     return res.redirect(auth.redirectAppUrl())
   } catch (error) {

--- a/server/constants/envConstant.ts
+++ b/server/constants/envConstant.ts
@@ -21,3 +21,7 @@ export const apiUrlBase = (): string => {
 export const appUrl = (): string => {
   return typeof process.env.APP_URL === 'string' ? process.env.APP_URL : ''
 }
+
+export const stage = (): string => {
+  return typeof process.env.STAGE === 'string' ? process.env.STAGE : 'local'
+}

--- a/server/domain/auth.ts
+++ b/server/domain/auth.ts
@@ -1,6 +1,7 @@
 import url from 'url'
 import uuid from 'uuid'
 import { AxiosResponse, AxiosError } from 'axios'
+import { CookieOptions } from 'express'
 import QiitaApiFactory from '../factroy/api/qiitaApiFactory'
 import QiitaStockerApiFactory from '../factroy/api/qiitaStockerApiFactory'
 import {
@@ -186,4 +187,19 @@ const issueLoginSession = async (
     issueLoginSessionRequest
   )
   return issueLoginSessionResponse.sessionId
+}
+
+export const loginSessionCookieOptions = (isLocal = false): CookieOptions => {
+  const nowDate = new Date()
+  // ログインセッションが無効になるのは30日後なのでそれより早めに29日でCookieは無効にする
+  nowDate.setDate(nowDate.getDate() + 29)
+
+  const secure = !isLocal
+
+  return {
+    expires: nowDate,
+    httpOnly: true,
+    path: '/',
+    secure
+  }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/234

# Doneの定義
- https://github.com/nekochans/qiita-stocker-frontend/issues/234 の完了の定義を満たしている事

# 変更点概要

## 技術的変更点概要
- ログインセッションのCookie有効期限を29日（サーバーの有効期限の1日前）に変更
- ログインセッションCookieに `secure` を明示的に追加

# 補足情報
`secure` を設定したほうがHTTPS環境下でしかCookieを読み込めなくなるので安全性が高くなると判断し追加。

※ ステージング環境で動作確認済