### PR TITLE
コールドスタート対策の手法をProvisioned Concurrencyに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "s3": "^4.4.0",
     "sass-loader": "^8.0.0",
     "serverless": "^1.60.4",
-    "serverless-plugin-warmup": "^4.7.1-rc.1",
     "ts-jest": "^24.2.0",
     "ts-loader": "^6.2.1",
     "ts-node": "^8.5.4",

--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,5 @@ app.use(async (req, res, next) => {
   await nuxt.ready()
   nuxt.render(req, res, next)
 })
-// app.use(nuxt.render)
 
 export default app

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,9 +27,6 @@ provider:
     GOOGLE_SITE_VERIFICATION: ${env:GOOGLE_SITE_VERIFICATION}
     TRACKING_ID: ${env:TRACKING_ID}
 
-plugins:
-  - serverless-plugin-warmup
-
 package:
   individually: true
   exclude:
@@ -62,7 +59,6 @@ package:
 functions:
   render:
     handler: dist/server/lambda.render
-    warmup: true
     events:
       - http:
           path: '/'
@@ -73,3 +69,4 @@ functions:
       - http:
           path: '/api/{proxy+}'
           method: any
+    provisionedConcurrency: 2

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,7 @@ package:
     - LICENSE
     - nodemon.json
     - package.json
-    - qiita-stocker-nuxt.iml
+    - qiita-stocker-frontend.iml
     - README.md
     - tsconfig.json
     - tsconfig.server.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,7 +2389,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-atob@^2.1.1:
+atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
@@ -4736,9 +4736,9 @@ eslint-plugin-import@^2.18.2:
     resolve "^1.12.0"
 
 eslint-plugin-jest@^23.0.4:
-  version "23.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.1.1.tgz#1220ab53d5a4bf5c3c4cd07c0dabc6199d4064dd"
-  integrity sha512-2oPxHKNh4j1zmJ6GaCBuGcb8FVZU7YjFUOJzGOPnl9ic7VA/MGAskArLJiRIlnFUmi1EUxY+UiATAy8dv8s5JA==
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.2.0.tgz#72d9ac0421b9b6ef774bcf4783329c016ed7cd6a"
+  integrity sha512-/jbCUW+g0jejXAvsytgcNhii6uEgolt0RO2e4+mhmXybfkcram5V3XIyrHCnUsb0vCmDKgHhJ1lYSm7F3VCEDA==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
@@ -10780,13 +10780,6 @@ server-destroy@^1.0.1:
   resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
   integrity sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=
 
-serverless-plugin-warmup@^4.7.1-rc.1:
-  version "4.7.1-rc.1"
-  resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-4.7.1-rc.1.tgz#33bbf2355e74295a29ef8a3482f7c30cae88b724"
-  integrity sha512-Z63tdBeHPZJGKYUF6HtkGEFzL4SDg5ghq3g0/NaR+mJxRi/xYr5/76CfPDBJKN5EnBC1kdpZiKnMCnoSE8z1Dg==
-  dependencies:
-    fs-extra "^8.1.0"
-
 serverless@^1.60.4:
   version "1.60.4"
   resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.60.4.tgz#aa761a6999cfe4f76217c9d6c81801e616f87529"
@@ -11026,11 +11019,11 @@ source-list-map@^2.0.0:
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
-  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
+  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
   dependencies:
-    atob "^2.1.1"
+    atob "^2.1.2"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/235

# Doneの定義
- https://github.com/nekochans/qiita-stocker-frontend/issues/235 の完了の定義を満たしている事

# 変更点概要

## 技術的変更点概要
- `serverless-plugin-warmup` を削除
- `serverless.yml` で `provisionedConcurrency` の設定を追加

以下の内容は本件とは直接関係ないが対応↓

- `serverless.yml`で exclude されていたファイルの中に `qiita-stocker-nuxt.iml` が含まれていたので `qiita-stocker-frontend.iml` に修正
- npm packageを最新安定版に更新（ [こちらのPR](https://github.com/nekochans/qiita-stocker-frontend/pull/242) はコンフリクトが発生していたのでこのPRの修正内容と同様の修正も本件に含まれている ）