### PR TITLE
Footerの年号を2020年に更新

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 nekochans
+Copyright (c) 2018-2020 nekochans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -20,7 +20,7 @@
         </div>
         <div class="level-right">
           <div class="content has-text-centered">
-            <p>Copyright (c) 2018-2019 nekochans</p>
+            <p>Copyright (c) 2018-2020 nekochans</p>
           </div>
         </div>
       </nav>

--- a/serverless.yml
+++ b/serverless.yml
@@ -69,4 +69,4 @@ functions:
       - http:
           path: '/api/{proxy+}'
           method: any
-    provisionedConcurrency: 2
+    provisionedConcurrency: 1


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-frontend/issues/245

# 関連URL
https://stg-www.nekochans.net

# Doneの定義
- https://github.com/nekochans/qiita-stocker-frontend/issues/245 の完了条件を満たしている事

# スクリーンショット

## PC
<img width="1448" alt="PC" src="https://user-images.githubusercontent.com/11032365/76618906-123c3e00-656d-11ea-963c-e6a85f2d1077.png">

## スマホ
<img width="546" alt="SP" src="https://user-images.githubusercontent.com/11032365/76618935-1d8f6980-656d-11ea-9a67-2657e2e2329d.png">

# 変更点概要

## 技術的変更点概要
- ライセンスとフッターの年号を2018-2020に変更

また https://github.com/nekochans/qiita-stocker-frontend/issues/245 とは関係ないが、https://github.com/nekochans/qiita-stocker-frontend/pull/243 で対応した Provisioned Concurrencyの設定値によってAWSの料金が1.5倍近くに増えているので、今回設定を最小値に更新した！