### PR TITLE
長期メンテナンス状態とする為、全てのルーティングを /maintenance にするように変更

### DIFF
--- a/app/components/pages/Maintenance.vue
+++ b/app/components/pages/Maintenance.vue
@@ -1,0 +1,24 @@
+<template>
+  <main>
+    <div class="container has-text-centered">
+      <h1 class="title">長期メンテナンス中です🐱</h1>
+      <h2 class="subtitle">{{ message }}</h2>
+    </div>
+  </main>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+
+@Component
+export default class extends Vue {
+  @Prop()
+  message!: string
+}
+</script>
+
+<style scoped>
+.subtitle {
+  padding-top: 1rem;
+}
+</style>

--- a/app/middleware/redirectMiddleware.ts
+++ b/app/middleware/redirectMiddleware.ts
@@ -1,28 +1,7 @@
 import { Context, Middleware } from '@nuxt/types'
 
-const redirectMiddleware: Middleware = ({
-  store,
-  redirect,
-  route
-}: Context) => {
-  const notRequiredAuthorization = [
-    '/',
-    '/signup',
-    '/privacy',
-    '/terms',
-    '/cancel/complete',
-    '/error'
-  ]
-
-  if (notRequiredAuthorization.includes(route.path)) return
-
-  if (store.getters['qiita/isLoggedIn'] && route.path === '/login') {
-    return redirect('/stocks/all')
-  }
-
-  if (!store.getters['qiita/isLoggedIn'] && route.path !== '/login') {
-    return redirect('/')
-  }
+const redirectMiddleware: Middleware = ({ redirect }: Context) => {
+  return redirect('/maintenance')
 }
 
 export default redirectMiddleware

--- a/app/pages/maintenance.vue
+++ b/app/pages/maintenance.vue
@@ -1,0 +1,29 @@
+<template>
+  <Maintenance :message="displayMessage" />
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import Maintenance from '@/components/pages/Maintenance.vue'
+
+@Component({
+  components: {
+    Maintenance
+  }
+})
+export default class extends Vue {
+  @Prop()
+  message!: string
+
+  displayMessage: string = ''
+
+  created() {
+    if (this.message) {
+      this.displayMessage = this.message
+    } else {
+      this.displayMessage =
+        '申し訳ありません。サービスは長期メンテナンス中です。'
+    }
+  }
+}
+</script>


### PR DESCRIPTION
# issueURL
なし

# 関連URL
- `/maintenance`

# Doneの定義
- 全てのURLが `/maintenance` にリダイレクトされるようになっている事

# スクリーンショット

![maintenance](https://user-images.githubusercontent.com/11032365/172317527-64e67188-b080-41e8-8a06-b0846403e719.png)

# 変更点概要

## 技術的変更点概要
LGTMeowの開発に力を入れているので、一旦長期メンテナンス状態としてバックエンドのサーバーは停止する。

フロント側をメンテナンス状態とする為に `/maintenance`  ページを作成し全てのルーティングを `/maintenance` に流すように変更。

# レビュアーに重点的にチェックして欲しい点
方針問題ないか確認してもらえると:pray:

# 補足情報
特になし